### PR TITLE
Add action to auto-create docs

### DIFF
--- a/.github/workflows/auto-docs-generate-reusable.yaml
+++ b/.github/workflows/auto-docs-generate-reusable.yaml
@@ -1,0 +1,87 @@
+name: Auto-docs generation reusable action
+
+on:
+  workflow_call:
+    inputs:
+      output_dir:
+        required: false
+        type: string
+        default: 'docs/auto-generated'
+        description: 'Directory where the generated documentation will be saved'
+      file_extension:
+        required: false
+        type: string
+        default: 'mdx'
+        description: 'File extension for the generated documentation file (e.g., md, mdx)'
+    secrets:
+      CLAUDE_API_KEY_ACTION_AUTO_DOCS:
+        required: true
+        description: 'API key for Claude AI'
+
+jobs:
+  generate_documentation:
+    if: contains(github.event.pull_request.labels.*.name, 'new feature') && github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout auto-docs scripts
+        uses: actions/checkout@v4
+        with:
+          repository: josh-wong/actions
+          sparse-checkout: auto-docs-script
+          ref: main
+          path: auto-docs
+
+      - name: Checkout the target repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+          path: repo
+      
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install anthropic==0.16.0 requests
+          pip list
+      
+      - name: Generate Documentation
+        working-directory: repo
+        env:
+          SCRIPT_PATH: ../auto-docs/auto-docs-script
+          CLAUDE_API_KEY_ACTION_AUTO_DOCS: ${{ secrets.CLAUDE_API_KEY_ACTION_AUTO_DOCS }}
+          OUTPUT_DIR: ${{ inputs.output_dir }}
+          FILE_EXTENSION: ${{ inputs.file_extension }}
+        run: |
+          # Create output directory if it doesn't exist
+          mkdir -p $OUTPUT_DIR
+          
+          # Run the documentation generation script
+          python $SCRIPT_PATH/generate_docs.py \
+            --pr-number "${{ github.event.pull_request.number }}" \
+            --pr-url "${{ github.event.pull_request.html_url }}" \
+            --pr-title "${{ github.event.pull_request.title }}" \
+            --pr-body "${{ github.event.pull_request.body }}" \
+            --repo "${{ github.repository }}" \
+            --output-dir "$OUTPUT_DIR" \
+            --file-extension "$FILE_EXTENSION"
+
+      - name: Create Pull Request with Documentation
+        uses: peter-evans/create-pull-request@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          path: repo
+          commit-message: "docs: auto-generated documentation for PR #${{ github.event.pull_request.number }}"
+          title: "Auto-generated docs for feature: ${{ github.event.pull_request.title }}"
+          body: |
+            This PR contains auto-generated documentation for the new feature introduced in PR #${{ github.event.pull_request.number }}.
+            
+            Original PR: ${{ github.event.pull_request.html_url }}
+            
+            Please review and edit the documentation as needed before publishing.
+          branch: auto-docs-pr-${{ github.event.pull_request.number }}
+          draft: true

--- a/auto-docs-script/README.md
+++ b/auto-docs-script/README.md
@@ -1,0 +1,60 @@
+# Auto Documentation Generator
+
+This folder contains scripts used by the auto-docs reusable GitHub Action workflow to generate documentation drafts based on merged pull requests with the "new feature" label.
+
+## How it works
+
+The auto-docs-generate-reusable.yaml workflow:
+
+1. Triggers when a pull request with the "new feature" label is merged.
+2. Uses the Claude API to analyze the PR content.
+3. Generates a documentation draft as a Markdown/MDX file.
+4. Creates a draft PR with the generated documentation.
+
+## Using this workflow in your repository
+
+To use this workflow in your repository, create a new workflow file in your repo with the following content:
+
+```yaml
+name: Generate Documentation for New Features
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main # Or your default branch.
+
+jobs:
+  generate-docs:
+    if: github.event.pull_request.merged == true
+    uses: josh-wong/actions/.github/workflows/auto-docs-generate-reusable.yaml@main
+    with:
+      output_dir: 'docs/auto-generated' # Optional. Defaults to docs/auto-generated.
+      file_extension: 'mdx' # Optional. Defaults to .mdx.
+    secrets:
+      CLAUDE_API_KEY_ACTION_AUTO_DOCS: ${{ secrets.CLAUDE_API_KEY_ACTION_AUTO_DOCS }}
+```
+
+## Prerequisites
+
+- You need to set up the `CLAUDE_API_KEY_ACTION_AUTO_DOCS` secret in your repository.
+- The repository must have the GitHub CLI installed on the runner.
+- Pull requests must be labeled with "new feature" to trigger documentation generation.
+
+## Configuration
+
+The workflow accepts the following inputs:
+
+- `output_dir`: Directory where the generated documentation will be saved (default: `docs/auto-generated`)
+- `file_extension`: File extension for the generated documentation file (default: `mdx`)
+
+## Generated documentation format
+
+The documentation is generated with the following sections:
+
+1. Overview - A brief description of the feature
+2. Purpose - Why this feature was added and what problem it solves
+3. How it works - Technical explanation of the implementation
+4. Usage - How to use this feature, with code examples if applicable
+5. Configuration - Any configuration options or settings
+6. Related features or components - How this feature interacts with other parts of the system

--- a/auto-docs-script/generate_docs.py
+++ b/auto-docs-script/generate_docs.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""
+Script to generate documentation drafts from PR content using Claude API.
+This script is intended to be run as part of a GitHub workflow action.
+"""
+
+import os
+import sys
+import json
+import argparse
+import datetime
+from pathlib import Path
+import anthropic
+import requests
+import subprocess
+
+def get_pr_diff(repo, pr_number):
+    """Get the content of the PR as a diff."""
+    try:
+        # Use GitHub CLI to get diff
+        result = subprocess.run(
+            ["gh", "pr", "diff", str(pr_number)],
+            capture_output=True,
+            text=True,
+            check=True
+        )
+        return result.stdout
+    except subprocess.CalledProcessError as e:
+        print(f"Error fetching PR diff: {e}")
+        print(f"stderr: {e.stderr}")
+        return None
+
+def get_pr_files(repo, pr_number):
+    """Get the list of files changed in the PR."""
+    try:
+        result = subprocess.run(
+            ["gh", "pr", "view", str(pr_number), "--json", "files"],
+            capture_output=True,
+            text=True,
+            check=True
+        )
+        files_data = json.loads(result.stdout)
+        return files_data.get("files", [])
+    except subprocess.CalledProcessError as e:
+        print(f"Error fetching PR files: {e}")
+        print(f"stderr: {e.stderr}")
+        return []
+
+def generate_documentation(pr_data, diff_content, files_changed):
+    """Generate documentation using Claude API."""
+    api_key = os.environ.get("CLAUDE_API_KEY_ACTION_AUTO_DOCS")
+    if not api_key:
+        print("Error: The CLAUDE_API_KEY_ACTION_AUTO_DOCS environment variable is not set.")
+        sys.exit(1)
+
+    client = anthropic.Anthropic(api_key=api_key)
+    
+    # Construct the prompt for Claude
+    prompt = f"""
+You are a technical writer creating documentation for a new feature that was just merged into a software project.
+
+Here is information about the feature from the pull request:
+- Title: {pr_data['title']}
+- Description: {pr_data['body']}
+- PR URL: {pr_data['url']}
+
+Files changed in this PR:
+{json.dumps([f['path'] for f in files_changed], indent=2)}
+
+Here is the diff showing the changes:
+```diff
+{diff_content[:10000] if diff_content else "No diff available"}
+```
+
+Based on this information, generate comprehensive documentation for this new feature in MDX (.mdx) format. Include the following sections:
+
+1. Overview - A brief description of the feature (Don't include this as a heading. Instead, put the overview content below the title.)
+2. Purpose - Why this feature was added and what problem it solves
+3. How this feature works - Technical explanation of the implementation
+4. Usage - How to use this feature, with code examples if applicable
+5. Configuration - Any configuration options or settings
+6. Related features or components - How this feature interacts with other parts of the system
+
+Format the documentation by using proper Markdown syntax with clear headings, code blocks, tables, etc. and by using Markdown best practices.
+"""
+
+    # Call Claude API
+    try:
+        response = client.messages.create(
+            model="claude-3-5-haiku-latest",
+            max_tokens=8192,
+            temperature=0.7,
+            system="You are an expert technical writer who creates clear, concise documentation for software features.",
+            messages=[
+                {"role": "user", "content": prompt}
+            ]
+        )
+        return response.content[0].text
+    except Exception as e:
+        print(f"Error calling Claude API: {e}")
+        return None
+
+def main():
+    parser = argparse.ArgumentParser(description='Generate documentation from PR content')
+    parser.add_argument('--pr-number', required=True, help='PR number')
+    parser.add_argument('--pr-url', required=True, help='PR URL')
+    parser.add_argument('--pr-title', required=True, help='PR title')
+    parser.add_argument('--pr-body', required=True, help='PR body')
+    parser.add_argument('--repo', required=True, help='Repository name')
+    parser.add_argument('--output-dir', default='docs/auto-generated', help='Output directory')
+    parser.add_argument('--file-extension', default='mdx', help='File extension for the generated doc')
+    
+    args = parser.parse_args()
+    
+    pr_data = {
+        'number': args.pr_number,
+        'url': args.pr_url,
+        'title': args.pr_title,
+        'body': args.pr_body
+    }
+    
+    # Get PR content
+    diff_content = get_pr_diff(args.repo, args.pr_number)
+    files_changed = get_pr_files(args.repo, args.pr_number)
+    
+    # Generate documentation
+    doc_content = generate_documentation(pr_data, diff_content, files_changed)
+    
+    if not doc_content:
+        print("Failed to generate documentation.")
+        sys.exit(1)
+    
+    # Sanitize title for filename
+    safe_title = args.pr_title.lower().replace(' ', '-')
+    safe_title = ''.join(c for c in safe_title if c.isalnum() or c == '-')
+    
+    # Create output filename
+    today = datetime.datetime.now().strftime('%Y-%m-%d')
+    filename = f"{today}-{safe_title}.{args.file_extension}"
+    output_path = os.path.join(args.output_dir, filename)
+    
+    # Make sure the output directory exists
+    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+    
+    # Add frontmatter to the content
+    frontmatter = f"""---
+tags: ["New feature"]
+---
+
+"""
+    
+    # Write the documentation
+    with open(output_path, 'w') as f:
+        f.write(frontmatter + doc_content)
+    
+    print(f"Documentation generated and saved to {output_path}.")
+    
+if __name__ == "__main__":
+    main()

--- a/auto-docs-script/sample-usage.yaml
+++ b/auto-docs-script/sample-usage.yaml
@@ -1,0 +1,17 @@
+name: Generate Documentation for New Features
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main # Or your default branch.
+
+jobs:
+  generate-docs:
+    if: github.event.pull_request.merged == true
+    uses: josh-wong/actions/.github/workflows/auto-docs-generate-reusable.yaml@main
+    with:
+      output_dir: 'docs/auto-generated' # Optional. Defaults to docs/auto-generated.
+      file_extension: 'mdx' # Optional. Defaults to .mdx.
+    secrets:
+      CLAUDE_API_KEY_ACTION_AUTO_DOCS: ${{ secrets.CLAUDE_API_KEY_ACTION_AUTO_DOCS }}

--- a/auto-docs-script/setup_dependencies.sh
+++ b/auto-docs-script/setup_dependencies.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Script to install dependencies for auto-docs generation
+
+# Ensure the script fails on any error
+set -e
+
+echo "Installing dependencies for auto-docs generation..."
+
+# Install Python packages
+python -m pip install --upgrade pip
+pip install anthropic requests
+
+# Check if GitHub CLI is installed
+if ! command -v gh &> /dev/null; then
+    echo "GitHub CLI not found, installing..."
+    
+    # Different installation methods based on the OS
+    if [ "$(uname)" == "Darwin" ]; then
+        # macOS
+        brew install gh
+    elif [ "$(uname)" == "Linux" ]; then
+        # Linux
+        curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+        echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+        sudo apt update
+        sudo apt install gh
+    else
+        echo "Unsupported OS for automatic GitHub CLI installation."
+        echo "Please install GitHub CLI manually: https://github.com/cli/cli#installation"
+        exit 1
+    fi
+fi
+
+# Verify installations
+echo "Verifying installations..."
+pip list | grep anthropic
+gh --version
+
+echo "All dependencies installed successfully."
+echo "Note: Make sure to set the CLAUDE_API_KEY_ACTION_AUTO_DOCS environment variable before using the scripts."

--- a/auto-docs-script/test_claude_api.py
+++ b/auto-docs-script/test_claude_api.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""
+This is a simple test script to verify Claude API connection and functionality.
+"""
+
+import os
+import sys
+import anthropic
+
+def test_claude_connection():
+    """Test the connection to the Claude API."""
+    api_key = os.environ.get("CLAUDE_API_KEY_ACTION_AUTO_DOCS")
+    if not api_key:
+        print("Error: The CLAUDE_API_KEY_ACTION_AUTO_DOCS environment variable is not set.")
+        sys.exit(1)
+
+    try:
+        client = anthropic.Anthropic(api_key=api_key)
+        
+        response = client.messages.create(
+            model="claude-3-5-haiku-latest",
+            max_tokens=8192, # Maximum number of tokens in the response
+            temperature=0.7, # Randomness control (0.0-1.0)
+            messages=[
+                {"role": "user", "content": "Hello, this is a test connection to the Claude API. If you receive this message, please respond with 'Connection successful' and mention what you are."}
+            ]
+        )
+        
+        print("API Response:")
+        print(response.content[0].text)
+        print("\nConnection test completed successfully.")
+        
+    except Exception as e:
+        print(f"Error testing Claude API connection: {e}")
+        sys.exit(1)
+
+if __name__ == "__main__":
+    test_claude_connection()


### PR DESCRIPTION
## Description

This PR adds a reusable GitHub Action workflow for automatically generating documentation drafts based on merged PRs labeled as "new feature." It includes the creation of scripts, configuration files, and documentation to support this functionality.

## Related issues and/or PRs

N/A

## Changes made

### Workflow implementation

* [`.github/workflows/auto-docs-generate-reusable.yaml`](diffhunk://#diff-6c2a5f7173c93dc40fa75f2d0cee4a2cde01ebca32dcb03d50057b3f2f8a7fa2R1-R87): Added a reusable GitHub Action workflow to generate documentation drafts for pull requests labeled "new feature" upon merging. It uses the Claude API for content generation and creates a draft pull request with the generated documentation.

### Script development

* [`auto-docs-script/generate_docs.py`](diffhunk://#diff-0673f91abc2ece8b71be5be95f18036afc0c4c3b32b8abfa00feb85c8655c50cR1-R159): Created a Python script to generate documentation drafts using the Claude API. It fetches pull request details, generates documentation based on a structured prompt, and saves the output in the specified format and directory.
* [`auto-docs-script/setup_dependencies.sh`](diffhunk://#diff-fa4bcb76dfd440fb87a2aed62c2929159abbf77997ae57ccd2abe57915dafb44R1-R40): Added a script to install necessary dependencies, including Python packages and the GitHub CLI, ensuring the environment is ready for auto-docs generation.

### Testing

* [`auto-docs-script/test_claude_api.py`](diffhunk://#diff-d60924930cc912836347d7667ca2103e5124a46fa8e50c5974d5ce130ed6219eR1-R38): Added a test script to verify the connection and functionality of the Claude API, ensuring it is ready for documentation generation.

### Documentation

* [`auto-docs-script/README.md`](diffhunk://#diff-b048eda1f390cede0ad2c4da51a24b0c06a01cd4c69a54bdea0cff4ac289203dR1-R60): Added documentation explaining the auto-docs workflow, its prerequisites, configuration options, and the format of generated documentation.

<h2 id="checklist">Checklist</h2>

If any items in this checklist aren't applicable to this PR, add `N/A` after the item and check the checkbox.

### Documentation

- [x] I have updated the documentation to reflect the changes.
- [x] I have documented or updated any remaining open issues linked to this PR in GitHub, Obsidian, etc.

### Build, deploy, and test

- [x] I have merged and published any dependent changes in other PRs.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have thoroughly tested my changes and confirmed functionality. `N/A` (Can't easily test if this workflow works until it's live)
- [x] My changes generate no new warnings.