### PR TITLE
Make auto-docs generation workflow skip PRs it created

### DIFF
--- a/.github/workflows/auto-docs-generate-reusable.yaml
+++ b/.github/workflows/auto-docs-generate-reusable.yaml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   generate_documentation:
-    if: contains(github.event.pull_request.labels.*.name, 'new feature') && github.event.pull_request.merged == true
+    if: contains(github.event.pull_request.labels.*.name, 'new feature') && github.event.pull_request.merged == true && !startsWith(github.event.pull_request.title, 'Auto-generated docs for new feature:')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout auto-docs scripts


### PR DESCRIPTION
## Description

This PR updates the workflow configuration for auto-documentation generation. The change ensures that the workflow does not run for pull requests with auto-generated documentation titles.

## Related issues and/or PRs

N/A

## Changes made

* [`.github/workflows/auto-docs-generate-reusable.yaml`](diffhunk://#diff-6c2a5f7173c93dc40fa75f2d0cee4a2cde01ebca32dcb03d50057b3f2f8a7fa2L23-R23): Added a condition to exclude pull requests where the title starts with "Auto-generated docs for new feature:" from triggering the `generate_documentation` job.

<h2 id="checklist">Checklist</h2>

If any items in this checklist aren't applicable to this PR, add `N/A` after the item and check the checkbox.

### Documentation

- [x] I have updated the documentation to reflect the changes. `N/A`
- [x] I have documented or updated any remaining open issues linked to this PR in GitHub, Obsidian, etc. `N/A`

### Build, deploy, and test

- [x] I have merged and published any dependent changes in other PRs. `N/A`
- [x] I have commented my code, particularly in hard-to-understand areas. `N/A`
- [x] I have thoroughly tested my changes and confirmed functionality.
- [x] My changes generate no new warnings.