### PR TITLE
Add action to auto-translate Markdown doc from English to Japanese by using OpenAI GPT model

### DIFF
--- a/.github/workflows/auto-translate-markdown-reusable.yaml
+++ b/.github/workflows/auto-translate-markdown-reusable.yaml
@@ -1,0 +1,67 @@
+name: Translate English docs to Japanese
+
+on:
+  push:
+    branches:
+      - main
+      - '**' # This allows the workflow to run on any branch. This can be changed to allow the workflow to run only on specific branches, like '1*', which would make the workflow run on branches named 1, 1.2, 1.2.3, etc.
+    paths:
+      - 'docs/en-us/**'
+
+jobs:
+  translate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: pip install openai
+
+      - name: Get changed files
+        id: changes
+        run: |
+          echo "files=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }} -- 'docs/en-us/' | tr '\n' ' ')" >> $GITHUB_OUTPUT
+
+      - name: Translate updated files
+        if: steps.changes.outputs.files != ''
+        run: |
+          mkdir translated
+          for file in ${{ steps.changes.outputs.files }}; do
+            python translate-docs.py "$file"
+          done
+
+      - name: Get English PR title
+        id: get_pr_title
+        run: |
+          PR_TITLE=$(gh pr view ${{ github.event.pull_request.number }} --json title -q '.title')
+          echo "title=${PR_TITLE}" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create PR with translated docs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          BRANCH="translate-ja-${{ github.run_id }}"
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git checkout -b $BRANCH
+          git add docs/ja-jp
+          git commit -m "Translate docs to Japanese"
+          git push origin $BRANCH
+
+          PR_TITLE="[Japanese] ${{ steps.get_pr_title.outputs.title }}"
+          gh pr create --title "$PR_TITLE" \
+                       --body "Automated translation of updated English docs" \
+                       --base ${{ github.ref_name }} \
+                       --head $BRANCH

--- a/.github/workflows/auto-translate-markdown-reusable.yaml
+++ b/.github/workflows/auto-translate-markdown-reusable.yaml
@@ -1,4 +1,4 @@
-name: Translate English docs to Japanese
+name: Auto-translate Markdown docs from English to Japanese
 
 on:
   push:

--- a/.github/workflows/auto-translate-markdown-reusable.yaml
+++ b/.github/workflows/auto-translate-markdown-reusable.yaml
@@ -50,7 +50,7 @@ jobs:
       - name: Create PR with translated docs
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENAI_API_KEY_ACTION_TRANSLATE_DOCS: ${{ secrets.OPENAI_API_KEY_ACTION_TRANSLATE_DOCS }}
         run: |
           BRANCH="translate-ja-${{ github.run_id }}"
           git config user.name "github-actions"

--- a/auto-translate-markdown-script/auto-translate.py
+++ b/auto-translate-markdown-script/auto-translate.py
@@ -3,7 +3,7 @@ import openai
 import sys
 from pathlib import Path
 
-openai.api_key = os.getenv("OPENAI_API_KEY")
+openai.api_key = os.getenv("OPENAI_API_KEY_ACTION_TRANSLATE_DOCS")
 
 def translate_file(source_path, target_path):
     with open(source_path, "r", encoding="utf-8") as f:

--- a/auto-translate-markdown-script/auto-translate.py
+++ b/auto-translate-markdown-script/auto-translate.py
@@ -1,0 +1,29 @@
+import os
+import openai
+import sys
+from pathlib import Path
+
+openai.api_key = os.getenv("OPENAI_API_KEY")
+
+def translate_file(source_path, target_path):
+    with open(source_path, "r", encoding="utf-8") as f:
+        content = f.read()
+
+    prompt = f"Translate the following Markdown documentation from English to Japanese:\n\n{content}"
+
+    response = openai.ChatCompletion.create(
+        model="gpt-4o",
+        messages=[{"role": "user", "content": prompt}],
+        temperature=0.3,
+    )
+
+    translation = response['choices'][0]['message']['content']
+
+    os.makedirs(os.path.dirname(target_path), exist_ok=True)
+    with open(target_path, "w", encoding="utf-8") as f:
+        f.write(translation)
+
+if __name__ == "__main__":
+    source = Path(sys.argv[1])
+    target = Path(str(source).replace("docs/en-us", "docs/ja-jp"))
+    translate_file(source, target)

--- a/auto-translate-markdown-script/sample-usage.yaml
+++ b/auto-translate-markdown-script/sample-usage.yaml
@@ -1,0 +1,19 @@
+name: 📄 Translate new Markdown files from English to Japanese
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+      - '**' # This allows the workflow to run on any branch. This can be changed to allow the workflow to run only on specific branches, like '1*', which would make the workflow run on branches named 1, 1.2, 1.2.3, etc.
+  workflow_dispatch:
+
+jobs:
+  translate-docs:
+    if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
+    uses: josh-wong/actions/.github/workflows/auto-translate-markdown-reusable.yaml@main
+    with:
+      output_dir: 'docs/ja-jp'
+      file_extension: 'mdx'
+    secrets:
+      OPENAI_API_KEY_ACTION_TRANSLATE_DOCS: ${{ secrets.OPENAI_API_KEY_ACTION_TRANSLATE_DOCS }} # Required. Your OpenAI API key for translation. Make sure to set this secret in your repository settings.


### PR DESCRIPTION
## Description

This PR introduces an automated workflow for translating English Markdown (`.mdx`) documentation into Japanese by using an OpenAI GPT model. The changes include defining reusable GitHub Actions workflows, implementing a Python script for translation, and providing a sample usage configuration.

## Related issues and/or PRs

N/A

## Changes made

* Workflow automation for translation
  * [`.github/workflows/auto-translate-markdown-reusable.yaml`](diffhunk://#diff-01c8af1ccae43fea2db3d6f5960ab7924edaafac33050a866d053e1af6b3791aR1-R67): Added a reusable GitHub Actions workflow to detect changes in English Markdown files, translate them to Japanese using OpenAI, and create a pull request for the translated files.

* Python script for translation
  * [`auto-translate-markdown-script/auto-translate.py`](diffhunk://#diff-2d385524aeaef0991905e8e2967cb910c49d99755685fed27a2ea8932ab29c4eR1-R29): Implemented a Python script that uses OpenAI's GPT model to translate English Markdown files to Japanese. The script reads the source file, generates a translation, and writes the output to the target directory.

* Sample usage configuration
  * [`auto-translate-markdown-script/sample-usage.yaml`](diffhunk://#diff-08eb99dc41e4fe148c6ad81f0c3dc320c00a00be509eb6b5179c2a21849fdc64R1-R19): Provided a sample configuration for triggering the translation workflow on pull request merges or manual dispatch, showcasing how to use the reusable workflow.

<h2 id="checklist">Checklist</h2>

If any items in this checklist aren't applicable to this PR, add `N/A` after the item and check the checkbox.

### Documentation

- [x] I have updated the documentation to reflect the changes.
- [x] I have documented or updated any remaining open issues linked to this PR in GitHub, Obsidian, etc.

### Build, deploy, and test

- [x] I have merged and published any dependent changes in other PRs.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have thoroughly tested my changes and confirmed functionality.
- [x] My changes generate no new warnings.