### PR TITLE
Fix workflow by using `on.workflow_call`

### DIFF
--- a/.github/workflows/auto-translate-markdown-reusable.yaml
+++ b/.github/workflows/auto-translate-markdown-reusable.yaml
@@ -1,12 +1,22 @@
 name: Auto-translate Markdown docs from English to Japanese
 
 on:
-  push:
-    branches:
-      - main
-      - '**' # This allows the workflow to run on any branch. This can be changed to allow the workflow to run only on specific branches, like '1*', which would make the workflow run on branches named 1, 1.2, 1.2.3, etc.
-    paths:
-      - 'docs/en-us/**'
+  workflow_call:
+    inputs:
+      output_dir:
+        required: false
+        type: string
+        default: 'docs/ja-jp'
+        description: 'Directory where the generated translation will be saved'
+      file_extension:
+        required: false
+        type: string
+        default: 'mdx'
+        description: 'File extension for the generated documentation file (e.g., md, mdx)'
+    secrets:
+      OPENAI_API_KEY_ACTION_TRANSLATE_DOCS:
+        required: true
+        description: 'API key for OpenAI'
 
 jobs:
   translate:


### PR DESCRIPTION
## Description

This PR fixes the `.github/workflows/auto-translate-markdown-reusable.yaml` file to transition the workflow from being triggered by `push` events to being reusable via `workflow_call` so that it can be used from other repositories. It also introduces configurable inputs and secrets to improve flexibility and usability.

## Related issues and/or PRs

- **Original PR:** #8 

## Changes made

* Replaced `push` event triggers with `workflow_call`, enabling the workflow to be reusable by other workflows.
* Added configurable inputs, including `output_dir` (default: `docs/ja-jp`) and `file_extension` (default: `mdx`), to allow customization of the translation output directory and file extension.

<h2 id="checklist">Checklist</h2>

If any items in this checklist aren't applicable to this PR, add `N/A` after the item and check the checkbox.

### Documentation

- [x] I have updated the documentation to reflect the changes.
- [x] I have documented or updated any remaining open issues linked to this PR in GitHub, Obsidian, etc.

### Build, deploy, and test

- [x] I have merged and published any dependent changes in other PRs.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have thoroughly tested my changes and confirmed functionality.
- [x] My changes generate no new warnings.