### PR TITLE
Fix broken auto-translate action

### DIFF
--- a/.github/workflows/auto-translate-markdown-reusable.yaml
+++ b/.github/workflows/auto-translate-markdown-reusable.yaml
@@ -43,14 +43,25 @@ jobs:
 
       - name: Translate updated files
         if: steps.changes.outputs.files != ''
+        env:
+          OPENAI_API_KEY_ACTION_TRANSLATE_DOCS: ${{ secrets.OPENAI_API_KEY_ACTION_TRANSLATE_DOCS }}
+          OUTPUT_DIR: ${{ inputs.output_dir }}
+          FILE_EXTENSION: ${{ inputs.file_extension }}
         run: |
-          mkdir translated
+          mkdir -p ${{ inputs.output_dir }}
           for file in ${{ steps.changes.outputs.files }}; do
-            python auto-translate.py "$file"
+            echo "Translating $file"
+            python auto-translate-markdown-script/auto-translate.py "$file" "${{ inputs.output_dir }}" "${{ inputs.file_extension }}"
           done
+
+      - name: Debug - List translated files
+        run: |
+          echo "Contents of ${{ inputs.output_dir }}:"
+          ls -la ${{ inputs.output_dir }}
 
       - name: Get English PR title
         id: get_pr_title
+        if: github.event_name == 'pull_request'
         run: |
           PR_TITLE=$(gh pr view ${{ github.event.pull_request.number }} --json title -q '.title')
           echo "title=${PR_TITLE}" >> $GITHUB_OUTPUT
@@ -60,18 +71,28 @@ jobs:
       - name: Create PR with translated docs
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          OPENAI_API_KEY_ACTION_TRANSLATE_DOCS: ${{ secrets.OPENAI_API_KEY_ACTION_TRANSLATE_DOCS }}
         run: |
           BRANCH="translate-ja-${{ github.run_id }}"
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
           git checkout -b $BRANCH
-          git add docs/ja-jp
-          git commit -m "Translate doc to Japanese"
-          git push origin $BRANCH
+          git add ${{ inputs.output_dir }}
+          # Only commit and create PR if there are changes
+          if git diff --staged --quiet; then
+            echo "No changes to commit"
+            exit 0
+          else
+            git commit -m "Translate doc to Japanese"
+            git push origin $BRANCH
 
-          PR_TITLE="[Japanese] ${{ steps.get_pr_title.outputs.title }}"
-          gh pr create --title "$PR_TITLE" \
-                       --body "Automated translation of new English doc" \
-                       --base ${{ github.ref_name }} \
-                       --head $BRANCH
+            if [ "${{ github.event_name }}" == "pull_request" ]; then
+              PR_TITLE="[Japanese] ${{ steps.get_pr_title.outputs.title }}"
+            else
+              PR_TITLE="[Japanese] Translation update"
+            fi
+
+            gh pr create --title "$PR_TITLE" \
+                        --body "Automated translation of new English doc" \
+                        --base ${{ github.ref_name }} \
+                        --head $BRANCH
+          fi

--- a/auto-translate-markdown-script/auto-translate.py
+++ b/auto-translate-markdown-script/auto-translate.py
@@ -5,25 +5,55 @@ from pathlib import Path
 
 openai.api_key = os.getenv("OPENAI_API_KEY_ACTION_TRANSLATE_DOCS")
 
-def translate_file(source_path, target_path):
+def translate_file(source_path, output_dir, file_extension=None):
     with open(source_path, "r", encoding="utf-8") as f:
         content = f.read()
 
     prompt = f"Translate the following Markdown documentation from English to Japanese:\n\n{content}"
 
-    response = openai.ChatCompletion.create(
-        model="gpt-4o",
-        messages=[{"role": "user", "content": prompt}],
-        temperature=0.3,
-    )
+    try:
+        response = openai.ChatCompletion.create(
+            model="gpt-4o",
+            messages=[{"role": "user", "content": prompt}],
+            temperature=0.3,
+        )
+        translation = response['choices'][0]['message']['content']
 
-    translation = response['choices'][0]['message']['content']
+        # Get the relative path from source_path
+        source_rel_path = Path(source_path).name
 
-    os.makedirs(os.path.dirname(target_path), exist_ok=True)
-    with open(target_path, "w", encoding="utf-8") as f:
-        f.write(translation)
+        # Determine target file extension
+        if file_extension:
+            target_ext = file_extension
+        else:
+            target_ext = Path(source_path).suffix.lstrip('.')
+
+        # Create target path in the specified output directory
+        target_path = Path(output_dir) / f"{Path(source_path).stem}.{target_ext}"
+
+        print(f"Saving translation to {target_path}")
+        os.makedirs(os.path.dirname(target_path), exist_ok=True)
+        with open(target_path, "w", encoding="utf-8") as f:
+            f.write(translation)
+        print(f"Successfully translated {source_path} to {target_path}")
+
+    except Exception as e:
+        print(f"Error translating {source_path}: {str(e)}")
+        raise e
 
 if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python auto-translate.py <source_file> [output_dir] [file_extension]")
+        sys.exit(1)
+
     source = Path(sys.argv[1])
-    target = Path(str(source).replace("docs/en-us", "docs/ja-jp"))
-    translate_file(source, target)
+
+    output_dir = "docs/ja-jp"  # Default output directory
+    if len(sys.argv) > 2:
+        output_dir = sys.argv[2]
+
+    file_extension = None
+    if len(sys.argv) > 3:
+        file_extension = sys.argv[3]
+
+    translate_file(source, output_dir, file_extension)


### PR DESCRIPTION
## Description

This PR fixes the Markdown translation workflow, focusing on configurability, error handling, and debugging improvements. Key changes include updates to the reusable GitHub Actions workflow and the `auto-translate.py` script to allow dynamic output directories and file extensions, improve logging, and handle translation errors gracefully.

## Related issues and/or PRs

- **Original PR:** #8 
- **Subsequent fix attempts:**
  - #9
  - #10

## Changes made

* [`.github/workflows/auto-translate-markdown-reusable.yaml`](diffhunk://#diff-01c8af1ccae43fea2db3d6f5960ab7924edaafac33050a866d053e1af6b3791aR46-R64): Added support for dynamic output directories and file extensions via `env` variables (`OUTPUT_DIR`, `FILE_EXTENSION`). Debugging steps were added to list translated files after processing. Improved logic for creating pull requests, ensuring commits are only made if changes exist. [[1]](diffhunk://#diff-01c8af1ccae43fea2db3d6f5960ab7924edaafac33050a866d053e1af6b3791aR46-R64) [[2]](diffhunk://#diff-01c8af1ccae43fea2db3d6f5960ab7924edaafac33050a866d053e1af6b3791aL63-R98)
* [`auto-translate-markdown-script/auto-translate.py`](diffhunk://#diff-2d385524aeaef0991905e8e2967cb910c49d99755685fed27a2ea8932ab29c4eL8-R59): Updated the `translate_file` function to accept `output_dir` and `file_extension` parameters, enabling flexible file storage and naming conventions. Added error handling to catch translation issues and provide informative logs. Improved CLI usage instructions and default values for optional arguments.

<h2 id="checklist">Checklist</h2>

If any items in this checklist aren't applicable to this PR, add `N/A` after the item and check the checkbox.

### Documentation

- [x] I have updated the documentation to reflect the changes.
- [x] I have documented or updated any remaining open issues linked to this PR in GitHub, Obsidian, etc.

### Build, deploy, and test

- [x] I have merged and published any dependent changes in other PRs.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have thoroughly tested my changes and confirmed functionality.
- [x] My changes generate no new warnings.