### PR TITLE
Fix auto-translate action

### DIFF
--- a/.github/workflows/auto-translate-markdown-reusable.yaml
+++ b/.github/workflows/auto-translate-markdown-reusable.yaml
@@ -47,7 +47,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: josh-wong/actions
-          path: auto-translate-markdown-script
+          path: translation-tools
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -100,6 +100,11 @@ jobs:
           for file in ${{ steps.get_files.outputs.files }}; do
             echo "- $file"
           done
+          
+          # Debug information about repository structure
+          echo "Current working directory: $(pwd)"
+          echo "Repository contents:"
+          ls -la
 
       - name: Translate files
         if: steps.get_files.outputs.files != ''
@@ -111,7 +116,7 @@ jobs:
           mkdir -p ${{ inputs.output_dir }}
           for file in ${{ steps.get_files.outputs.files }}; do
             echo "Translating $file"
-            python auto-translate-markdown-script/auto-translate.py "$file" "${{ inputs.output_dir }}" "${{ inputs.file_extension }}"
+            python translation-tools/auto-translate-markdown-script/auto-translate.py "$file" "${{ inputs.output_dir }}" "${{ inputs.file_extension }}"
           done
 
       - name: Debug - List translated files

--- a/auto-translate-markdown-script/auto-translate.py
+++ b/auto-translate-markdown-script/auto-translate.py
@@ -1,9 +1,9 @@
 import os
-import openai
 import sys
 from pathlib import Path
+from openai import OpenAI
 
-openai.api_key = os.getenv("OPENAI_API_KEY_ACTION_TRANSLATE_DOCS")
+client = OpenAI(api_key=os.getenv("OPENAI_API_KEY_ACTION_TRANSLATE_DOCS"))
 
 def translate_file(source_path, output_dir, file_extension=None):
     with open(source_path, "r", encoding="utf-8") as f:
@@ -12,12 +12,12 @@ def translate_file(source_path, output_dir, file_extension=None):
     prompt = f"Translate the following Markdown documentation from English to Japanese:\n\n{content}"
 
     try:
-        response = openai.ChatCompletion.create(
+        response = client.chat.completions.create(
             model="gpt-4o",
             messages=[{"role": "user", "content": prompt}],
             temperature=0.3,
         )
-        translation = response['choices'][0]['message']['content']
+        translation = response.choices[0].message.content
 
         # Get the relative path from source_path
         source_rel_path = Path(source_path).name


### PR DESCRIPTION
## Description

This PR includes fixes to the translation workflow and the `auto-translate-markdown-script` Python script. The changes improve the repository structure, add debugging information, and modify the script to use a more structured OpenAI client for API calls.

## Related issues and/or PRs

- **Original PR:** #8 
- **Subsequent fix attempts:**
  - #9
  - #10
  - #11
  - #13
  - #14 

## Changes made

### Workflow updates

* [`.github/workflows/auto-translate-markdown-reusable.yaml`](diffhunk://#diff-01c8af1ccae43fea2db3d6f5960ab7924edaafac33050a866d053e1af6b3791aL50-R50): Changed the repository path from `auto-translate-markdown-script` to `translation-tools` for better organization.
* [`.github/workflows/auto-translate-markdown-reusable.yaml`](diffhunk://#diff-01c8af1ccae43fea2db3d6f5960ab7924edaafac33050a866d053e1af6b3791aR104-R108): Added debug commands to display the current working directory and repository contents for easier troubleshooting.
* [`.github/workflows/auto-translate-markdown-reusable.yaml`](diffhunk://#diff-01c8af1ccae43fea2db3d6f5960ab7924edaafac33050a866d053e1af6b3791aL114-R119): Updated the Python script path to reflect the new repository structure during file translation.

### Script updates

* [`auto-translate-markdown-script/auto-translate.py`](diffhunk://#diff-2d385524aeaef0991905e8e2967cb910c49d99755685fed27a2ea8932ab29c4eL2-R6): Replaced direct usage of `openai` with a structured `OpenAI` client for API calls, improving code readability and maintainability.
* [`auto-translate-markdown-script/auto-translate.py`](diffhunk://#diff-2d385524aeaef0991905e8e2967cb910c49d99755685fed27a2ea8932ab29c4eL15-R20): Updated the API call to use `client.chat.completions.create` and adjusted the response handling to align with the new client structure.

<h2 id="checklist">Checklist</h2>

If any items in this checklist aren't applicable to this PR, add `N/A` after the item and check the checkbox.

### Documentation

- [x] I have updated the documentation to reflect the changes.
- [x] I have documented or updated any remaining open issues linked to this PR in GitHub, Obsidian, etc.

### Build, deploy, and test

- [x] I have merged and published any dependent changes in other PRs.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have thoroughly tested my changes and confirmed functionality.
- [x] My changes generate no new warnings.