### PR TITLE
Add workflow to auto-translate English Markdown docs to Japanese by using Claude Code

### DIFF
--- a/.github/workflows/auto-translate-markdown-claude-reusable.yml
+++ b/.github/workflows/auto-translate-markdown-claude-reusable.yml
@@ -1,0 +1,80 @@
+name: Auto-Translate Markdown to Japanese
+
+on:
+  workflow_call:
+    secrets:
+      ANTHROPIC_API_KEY:
+        description: 'Anthropic API key for Claude Code'
+        required: true
+      GITHUB_TOKEN:
+        description: 'GitHub token with repo permissions'
+        required: true
+
+jobs:
+  translate-markdown:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+
+    steps:
+      - name: Checkout calling repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Checkout actions repository
+        uses: actions/checkout@v4
+        with:
+          repository: josh-wong/actions
+          path: .actions
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
+      - name: Install dependencies
+        run: |
+          cd .actions/auto-translate-markdown-claude
+          npm install
+
+      - name: Install Claude Code
+        run: npm install -g @anthropic-ai/claude-code
+
+      - name: Configure Git
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Run translation workflow
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          REPOSITORY_OWNER: ${{ github.repository_owner }}
+          REPOSITORY_NAME: ${{ github.event.repository.name }}
+        run: |
+          cd .actions/auto-translate-markdown-claude
+          node scripts/translate-markdown.js
+
+      - name: Comment on failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: ${{ github.event.pull_request.number }},
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '❌ **Auto-translation failed**\n\nThe automatic Japanese translation workflow encountered an error. Please check the [workflow logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details.'
+            })

--- a/auto-translate-markdown-claude/README.md
+++ b/auto-translate-markdown-claude/README.md
@@ -1,0 +1,325 @@
+# Auto-translate markdown to Japanese
+
+Automatically translate English Markdown files to Japanese when PRs are merged, using Claude Code for high-quality translations.
+
+## Overview
+
+This GitHub Actions workflow automatically:
+
+1. Detects merged PRs containing Markdown files.
+2. Translates English content to Japanese using Claude Code.
+3. Creates Japanese versions in `docs/ja-jp` directories.
+4. Opens a new PR with translations and proper metadata.
+
+## Features
+
+- **High-quality translation:** Uses Claude Code (Anthropic) for natural, technical translations.
+- **Markdown preservation:** Maintains all formatting, code blocks, and links.
+- **Front matter updates:** Automatically updates sidebar references.
+- **Translation banner:** Adds consistent translation notice.
+- **Anchor link fixing:** Updates internal links to match Japanese headings.
+- **PR metadata replication:** Copies reviewers, labels, and assignments.
+- **Error handling:** Graceful failure with detailed logging.
+
+## Setup
+
+### 1. Add repository secrets
+
+Add these secrets to your repository settings:
+
+- `ANTHROPIC_API_KEY`: Your Anthropic API key for Claude Code authentication
+
+### 2. Copy workflow files
+
+Copy the entire `auto-translate-markdown` directory to your repository:
+
+```markdown
+actions/
+├── .github/workflows/
+│   └── auto-translate-markdown.yml
+└── auto-translate-markdown/
+    ├── translate-markdown.js
+    ├── claude-code-translator.js
+    ├── file-processor.js
+    ├── pr-metadata-extractor.js
+    ├── anchor-link-fixer.js
+    └── package.json
+```
+
+### 3. Install dependencies
+
+The workflow automatically installs dependencies, but for local testing:
+
+```bash
+cd auto-translate-markdown
+npm install
+```
+
+### 4. Add translation banner component
+
+Add the translation banner component:
+
+```markdown
+import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
+
+<TranslationBanner />
+```
+
+## How it works
+
+### Trigger conditions
+
+The workflow triggers when:
+
+- A pull request is **merged** (not just closed).
+- The PR contains **modified or added** `.md` or `.mdx` files.
+- Files are **not** in existing `docs/ja-jp` directories.
+
+### Translation process
+
+1. **File detection:** Scans merged PR for eligible Markdown files.
+2. **Content processing:** Extracts front matter and body content.
+3. **Translation:** Uses Claude Code to translate while preserving structure.
+4. **File modification:**
+   - Updates `displayed_sidebar: docsEnglish` → `docsJapanese`.
+   - Adds translation banner after the title.
+   - Fixes anchor links to match Japanese headings.
+5. **PR creation:** Creates new PR with metadata from original.
+
+### File path mapping
+
+Original files are mapped to Japanese equivalents:
+
+```text
+docs/guides/getting-started.md → docs/ja-jp/guides/getting-started.md
+docs/api/reference.mdx → docs/ja-jp/api/reference.mdx
+README.md → docs/ja-jp/README.md
+```
+
+## Configuration
+
+### Environment variables
+
+Set these in the workflow or repository secrets:
+
+```yaml
+env:
+  ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}  # Required
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}            # Auto-provided
+```
+
+### Workflow inputs
+
+Customize behavior by modifying the configuration in `translate-markdown.js`:
+
+```javascript
+this.config = {
+  targetLanguage: 'ja-jp',
+  sidebarMapping: {
+    'docsEnglish': 'docsJapanese'
+  },
+  translationBannerPath: '/src/components/_translation-ja-jp.mdx',
+  fileExtensions: ['.md', '.mdx']
+};
+```
+
+### Sidebar mapping
+
+Add more sidebar mappings as needed:
+
+```javascript
+sidebarMapping: {
+  'docsEnglish': 'docsJapanese',
+  'apiEnglish': 'apiJapanese',
+  'guidesEnglish': 'guidesJapanese'
+}
+```
+
+## Translation quality
+
+### Best practices
+
+The workflow ensures high-quality translations by:
+
+- **Preserving structure:** All Markdown formatting is maintained exactly.
+- **Technical terms:** Code blocks and technical commands remain untranslated.
+- **Natural language:** Claude Code provides contextually appropriate Japanese.
+- **Consistency:** Translation banner and front-matter updates are standardized.
+
+### What gets translated
+
+✅ **Translated:**
+
+- Heading text
+- Body paragraphs
+- List items
+- Link text
+- Alt text for images
+- Table content
+
+❌ **Not translated:**
+
+- Code blocks and inline code
+- URLs and file paths
+- Front-matter property names
+- Technical commands
+- Repository names
+
+## Troubleshooting
+
+### Common issues
+
+#### 1. Authentication error
+
+```text
+Error: Claude Code CLI not found
+```
+
+- Ensure `ANTHROPIC_API_KEY` secret is set correctly.
+- Check API key has sufficient credits.
+
+#### 2. Translation timeout
+
+```text
+Error: Claude Code translation timed out
+```
+
+- Large files may timeout; consider splitting content.
+- Check Anthropic service status.
+
+#### 3. Git push failures
+
+```text
+Error: failed to push some refs
+```
+
+- Check repository permissions.
+- Ensure `GITHUB_TOKEN` has write access.
+
+#### 4. Missing dependencies
+
+```text
+Error: Cannot find module '@actions/core'
+```
+
+- Verify `package.json` includes all dependencies.
+- Check Node.js version compatibility.
+
+### Debugging
+
+Enable verbose logging by adding to workflow:
+
+```yaml
+- name: Enable debug logging
+  run: echo "ACTIONS_STEP_DEBUG=true" >> $GITHUB_ENV
+```
+
+Check workflow logs for detailed error information and translation progress.
+
+## Examples
+
+### Example PR description
+
+When the workflow creates a translation PR, it includes:
+
+```markdown
+## 🌐 Japanese translation
+
+This PR contains automatic Japanese translations generated from the content merged in PR #123.
+
+### 📁 Translated files
+- `docs/ja-jp/guides/getting-started.md` (from `docs/guides/getting-started.md`)
+- `docs/ja-jp/api/reference.mdx` (from `docs/api/reference.mdx`)
+
+### 🔗 Source
+
+- **Original PR:** #123 - Add new getting started guide
+- **Author:** @johndoe
+- **Branch:** `feature/new-guide`
+
+### 🤖 Translation details
+
+- **Target language:** Japanese (ja-jp)
+- **Translation method:** Claude Code (Anthropic)
+- **Translation banner:** Added to all translated files
+- **Sidebar:** Updated from "docsEnglish" to "docsJapanese"
+- **Anchor links:** Updated to match Japanese headings
+```
+
+### Example front matter changes
+
+**Before (English):**
+```yaml
+---
+title: Getting Started Guide
+displayed_sidebar: docsEnglish
+description: Learn how to get started
+---
+```
+
+**After (Japanese):**
+```yaml
+---
+title: Getting Started Guide
+displayed_sidebar: docsJapanese
+description: Learn how to get started
+translated: true
+translation_source: claude-code
+translation_date: 2025-06-30
+---
+```
+
+## Contributing
+
+### Local development
+
+1. Clone the repository.
+2. Install dependencies: `npm install`.
+3. Set environment variables:
+
+   ```bash
+   export ANTHROPIC_API_KEY="your-api-key"
+   export GITHUB_TOKEN="your-github-token"
+   ```
+
+4. Test individual components:
+
+   ```bash
+   node claude-code-translator.js
+   node file-processor.js
+   ```
+
+### Testing
+
+Test the workflow with sample content:
+
+```bash
+# Test translation
+echo "# Test Content\nThis is a test." > test.md
+node translate-markdown.js
+```
+
+### Extending
+
+To add support for other languages:
+
+1. Update `targetLanguage` configuration.
+2. Create appropriate translation banner components.
+3. Modify sidebar mappings.
+4. Update file path generation logic.
+
+## License
+
+MIT License. Feel free to use and modify for your projects.
+
+## Support
+
+For issues or questions:
+
+1. Check the [troubleshooting section](#troubleshooting).
+2. Review workflow logs for detailed error information.
+3. Open an issue with reproduction steps.
+
+---
+
+**Happy translating! 🌐✨**

--- a/auto-translate-markdown-claude/auto-translate-markdown-claude-design-clean.md
+++ b/auto-translate-markdown-claude/auto-translate-markdown-claude-design-clean.md
@@ -1,0 +1,222 @@
+# Auto-Translate Markdown to Japanese - Design Document
+
+This GitHub Actions workflow automatically translates newly merged English Markdown files (`.md`/`.mdx`) to Japanese, creating a pull request with the translated content in the target repository.
+
+## Workflow trigger
+
+The workflow triggers on:
+
+- `workflow_call` events for reusable workflow usage across repositories
+- Only processes files with extensions `.md`/`.mdx` in `docs/en-us/` directories
+- Only processes files that are added or modified (not deleted)
+- Requires `merged == true` condition on pull requests
+
+## High-level flow
+
+```mermaid
+graph TD
+    A[PR Merged] --> B[Checkout Calling Repo]
+    B --> C[Checkout Actions Repo]
+    C --> D[Detect Markdown files in docs/en-us/]
+    D --> E[Filter English files]
+    E --> F[Extract PR metadata]
+    F --> G[Create translation branch]
+    G --> H[Translate content via Claude Code]
+    H --> I[Modify front matter]
+    I --> J[Add translation banner]
+    J --> K[Fix anchor links]
+    K --> L[Create PR]
+    L --> M[Apply labels & assignments]
+```
+
+## Components
+
+### 1. File detection and filtering
+
+- **Input:** PR changed files from calling repository
+- **Logic:**
+  - Filter for `.md` and `.mdx` files in `docs/en-us/` directories
+  - Exclude files that are in `docs/ja-jp` directories  
+  - Only process added/modified files (not deleted)
+- **Output:** List of English Markdown files to translate
+
+### 2. PR metadata extraction
+
+- **Input:** Original PR data from calling repository
+- **Extract:**
+  - Original branch name
+  - PR title and description
+  - PR author and metadata
+- **Output:** Metadata object for replication
+
+### 3. Translation branch creation
+
+- **Input:** Original branch name
+- **Logic:** Create branch named `<ORIGINAL_BRANCH_NAME>-ja-jp`
+- **Output:** New branch reference
+
+### 4. Content translation
+
+- **Input:** English Markdown content
+- **Process:**
+  - Use Claude Code in non-interactive mode to translate content.
+  - Preserve Markdown structure and formatting.
+  - Maintain code blocks, links, and special syntax.
+  - Generate Japanese-appropriate anchor links for headings.
+- **Output:** Japanese Markdown content
+
+### 5. File modification
+
+- **Front-matter updates:**
+  - Change `displayed_sidebar: docsEnglish` to `displayed_sidebar: docsJapanese`.
+  - Preserve all other front-matter properties.
+- **Translation banner:**
+  - Add import statement after front matter
+  - Add banner component after title
+- **Anchor link fixing:**
+  - Update internal anchor links to match Japanese headings
+  - Preserve external links unchanged
+
+### 6. PR creation and metadata application
+
+- **Create PR** with translated content
+- **PR body:** Include reference to the original PR that triggered the translation
+- **Apply:**
+  - "documentation" label
+  - Original reviewers as reviewers
+  - Original author as assignee
+  - Same projects as original PR
+
+## File structure
+
+```markdown
+.github/workflows/
+└── auto-translate-markdown-claude-reusable.yml  # Reusable workflow file
+
+auto-translate-markdown-claude/
+├── scripts/                         # Core translation modules
+│   ├── translate-markdown.js        # Main translation logic
+│   ├── claude-code-translator.js    # Claude Code integration
+│   ├── file-processor.js           # File content manipulation
+│   ├── pr-metadata-extractor.js    # GitHub API utilities
+│   └── anchor-link-fixer.js        # Anchor link processing
+├── tests/                           # Comprehensive test suite
+│   ├── unit-tests.js               # Unit tests for all modules
+│   ├── integration-test.js         # Integration testing
+│   ├── local-test.js              # Local workflow testing
+│   ├── run-tests.js               # Test runner
+│   └── setup-dev-env.js           # Development environment setup
+├── package.json                    # Dependencies and scripts
+├── README.md                       # Usage documentation
+├── sample-usage.md                 # Configuration examples
+├── auto-translate-markdown-claude-design.md      # Full design document
+└── auto-translate-markdown-claude-design-clean.md # Clean design document
+```
+
+## Key features
+
+### Reusable workflow design
+
+- Designed as a `workflow_call` for cross-repository usage
+- Simple integration with minimal configuration required
+- Centralized maintenance and automatic updates
+- Version control with Git tags for stability
+
+### Translation quality
+
+- Uses Claude Code for high-quality translations
+- Preserves Markdown formatting and structure
+- Maintains technical terminology consistency
+- Handles code blocks and special syntax correctly
+
+### GitHub integration
+
+- Works across multiple repositories via reusable workflow
+- Replicates original PR metadata (author, title, description)
+- Applies appropriate labels and creates meaningful branch names
+- Handles errors gracefully with notifications
+
+### Content processing
+
+- Automatically updates front matter sidebar values
+- Adds translation banner component with proper imports
+- Fixes anchor links to match Japanese headings
+- Validates Markdown structure after translation
+- Supports custom sidebar mappings and translation banners
+
+### Testing and validation
+
+- Comprehensive test suite with unit, integration, and local tests
+- Mock translation capabilities for testing without API usage
+- Validation of all workflow components
+- Development environment setup scripts
+
+## Configuration
+
+### Environment variables
+
+- `ANTHROPIC_API_KEY`: Anthropic API key for Claude Code authentication
+- `GITHUB_TOKEN`: GitHub token with repo permissions (automatically provided)
+
+### Workflow usage
+
+#### Option 1: Reusable workflow (Recommended)
+```yaml
+jobs:
+  translate-markdown:
+    if: github.event.pull_request.merged == true
+    uses: josh-wong/actions/.github/workflows/auto-translate-markdown-claude-reusable.yml@main
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+#### Option 2: Self-contained workflow
+```yaml
+steps:
+  - uses: actions/checkout@v4
+    with:
+      repository: josh-wong/actions
+      path: .actions
+  - name: Run translation
+    run: |
+      cd .actions/auto-translate-markdown-claude
+      npm install
+      node scripts/translate-markdown.js
+```
+
+### Workflow inputs (configurable in scripts)
+
+- `target_language`: Default "ja-jp" (Japanese)
+- `sidebar_mapping`: Mapping for sidebar values (docsEnglish → docsJapanese)
+- `translation_banner_path`: Path to translation banner component
+- `file_extensions`: Extensions to process (default: [".md", ".mdx"])
+- `source_path_filter`: Default "docs/en-us/" for English source files
+
+## Success criteria
+
+1. ✅ Workflow triggers correctly on PR merge in calling repositories
+2. ✅ Accurately detects and filters Markdown files in `docs/en-us/` directories
+3. ✅ Successfully translates content via Claude Code with high quality
+4. ✅ Properly modifies front matter and adds translation banner
+5. ✅ Fixes anchor links to match translated Japanese headings
+6. ✅ Creates PR with correct metadata and reference to original PR
+7. ✅ Handles errors gracefully without breaking calling workflows
+8. ✅ Maintains translation quality and Markdown structure
+9. ✅ Processes multiple files efficiently in batch
+10. ✅ Supports reusable workflow pattern for easy adoption
+11. ✅ Comprehensive testing with unit, integration, and local test suites
+12. ✅ Clear documentation and usage examples for different scenarios
+
+## Implementation status
+
+All success criteria have been met:
+
+- ✅ **Core functionality**: Translation pipeline fully implemented and tested
+- ✅ **Reusable workflow**: Supports cross-repository usage via `workflow_call`
+- ✅ **File processing**: Front matter updates, banner addition, anchor link fixing
+- ✅ **Testing**: Comprehensive test suite with mock translation capabilities
+- ✅ **Documentation**: Complete usage guides and configuration examples
+- ✅ **Project structure**: Clean organization with scripts in dedicated folder
+- ✅ **Error handling**: Graceful failure with proper notifications
+- ✅ **Path filtering**: Only processes `docs/en-us/` files to avoid unnecessary runs

--- a/auto-translate-markdown-claude/auto-translate-markdown-claude-design.md
+++ b/auto-translate-markdown-claude/auto-translate-markdown-claude-design.md
@@ -1,0 +1,272 @@
+# Auto-Translate Markdown to Japanese - Design Document
+
+This GitHub Actions workflow automatically translates newly merged English Markdown files (`.md`/`.mdx`) to Japanese, creating a pull request with the translated content in the target repository.
+
+## Workflow trigger
+
+The workflow triggers on:
+
+- `workflow_call` events for reusable workflow usage across repositories
+- Only processes files with extensions `.md`/`.mdx` in `docs/en-us/` directories
+- Only processes files that are added or modified (not deleted)
+- Requires `merged == true` condition on pull requests
+
+## High-level flow
+
+```mermaid
+graph TD
+    A[PR Merged] --> B[Checkout Calling Repo]
+    B --> C[Checkout Actions Repo]
+    C --> D[Detect Markdown files in docs/en-us/]
+    D --> E[Filter English files]
+    E --> F[Extract PR metadata]
+    F --> G[Create translation branch]
+    G --> H[Translate content via Claude Code]
+    H --> I[Modify front matter]
+    I --> J[Add translation banner]
+    J --> K[Fix anchor links]
+    K --> L[Create PR]
+    L --> M[Apply labels & assignments]
+```
+
+## Components
+
+### 1. File detection and filtering
+
+- **Input:** PR changed files
+- **Logic:**
+  - Filter for `.md` and `.mdx` files
+  - Exclude files that are in `docs/ja-jp` directories
+  - Only process added/modified files (not deleted)
+- **Output:** List of English Markdown files to translate
+
+### 2. PR metadata extraction
+
+- **Input:** Original PR data
+- **Extract:**
+  - Original branch name
+  - PR author
+  - Reviewers list
+  - Applied labels
+  - Associated projects
+  - PR title and description
+- **Output:** Metadata object for replication
+
+### 3. Translation branch creation
+
+- **Input:** Original branch name
+- **Logic:** Create branch named `<ORIGINAL_BRANCH_NAME>-ja-jp`
+- **Output:** New branch reference
+
+### 4. Content translation
+
+- **Input:** English Markdown content
+- **Process:**
+  - Use Claude Code in non-interactive mode to translate content.
+  - Preserve Markdown structure and formatting.
+  - Maintain code blocks, links, and special syntax.
+  - Generate Japanese-appropriate anchor links for headings.
+- **Output:** Japanese Markdown content
+
+### 5. File modification
+
+- **Front-matter updates:**
+  - Change `displayed_sidebar: docsEnglish` to `displayed_sidebar: docsJapanese`.
+  - Preserve all other front-matter properties.
+- **Translation banner:**
+  - Add import statement after front matter
+  - Add banner component after title
+- **Anchor link fixing:**
+  - Update internal anchor links to match Japanese headings
+  - Preserve external links unchanged
+
+### 6. PR creation and metadata application
+
+- **Create PR** with translated content
+- **PR body:** Include reference to the original PR that triggered the translation
+- **Apply:**
+  - "documentation" label
+  - Original reviewers as reviewers
+  - Original author as assignee
+  - Same projects as original PR
+
+## File structure
+
+```markdown
+.github/workflows/
+└── auto-translate-markdown.yml     # Main workflow file
+
+auto-translate-markdown/
+├── translate-markdown.js           # Main translation logic
+├── claude-code-translator.js       # Claude Code integration
+├── file-processor.js              # File content manipulation
+├── pr-metadata-extractor.js       # GitHub API utilities
+└── anchor-link-fixer.js           # Anchor link processing
+
+package.json                        # Dependencies
+README.md                          # Usage documentation
+```
+
+## Configuration
+
+### Environment variables
+
+- `ANTHROPIC_API_KEY`: Anthropic API key for Claude Code authentication
+- `GITHUB_TOKEN`: GitHub token with repo permissions
+
+### Workflow inputs (configurable)
+
+- `target_language`: Default "ja-jp" (Japanese)
+- `sidebar_mapping`: Mapping for sidebar values
+- `translation_banner_path`: Path to translation banner component
+- `file_extensions`: Extensions to process (default: [".md", ".mdx"])
+
+## Translation process details
+
+### 1. Content preprocessing
+
+- Extract front matter
+- Identify code blocks and preserve them
+- Mark external links for preservation
+- Extract headings for anchor link mapping
+
+### 2. Claude Code integration
+
+- Use Claude Code in non-interactive mode with `-p` flag
+- Send structured request with context about Markdown preservation
+- Include instructions for Japanese translation best practices
+- Request heading translations for anchor link mapping
+- Preserve technical terms and code examples
+
+### 3. Content postprocessing
+
+- Update front matter with sidebar changes
+- Insert translation banner after title
+- Map old anchor links to new Japanese heading anchors
+- Validate Markdown structure
+
+## Error handling
+
+### Translation failures
+- Log translation errors
+- Skip problematic files and continue with others
+- Comment on original PR with failure details
+
+### API rate limiting
+
+- **Implement exponential backoff for Claude Code rate limiting**
+- Queue multiple files for batch processing
+- Respect GitHub API rate limits
+
+### Branch conflicts
+
+- Check if translation branch already exists
+- Handle merge conflicts gracefully
+- Update existing translation PRs if needed
+
+## Security considerations
+
+- Store API keys as GitHub Secrets
+- Validate file paths to prevent directory traversal
+- Sanitize content before translation
+- Limit file size for translation (e.g., max 50KB per file)
+
+## Testing strategy
+
+### Unit tests
+
+- File detection and filtering logic
+- Front-matter manipulation
+- Anchor link fixing
+- PR metadata extraction
+
+### Integration tests
+
+- End-to-end workflow with sample repositories
+- Claude API integration testing
+- GitHub API interaction testing
+
+### Test scenarios
+
+1. Single Markdown file translation
+2. Multiple files in one PR
+3. Files with complex front matter
+4. Files with multiple heading levels
+5. Files with existing anchor links
+6. Error scenarios (API failures, rate limits)
+
+## Performance considerations
+
+- **Parallel processing:** Translate multiple files concurrently
+- **Caching:** Cache translation results for similar content
+- **Batching:** Group small files for batch translation
+- **Timeouts:** Set appropriate timeouts for API calls
+
+## Monitoring and observability
+
+- Log translation success/failure rates
+- Track API usage and costs
+- Monitor workflow execution times
+- Alert on repeated failures
+
+## Future enhancements
+
+1. **Multi-language support:** Extend beyond Japanese
+2. **Custom translation rules:** Per-repository translation preferences
+3. **Review automation:** Auto-approve simple translations
+4. **Translation memory:** Reuse previous translations for consistency
+5. **Quality checks:** Automated translation quality validation
+
+## Dependencies
+
+### Node.js packages
+
+- `@actions/core`: GitHub Actions utilities
+- `@actions/github`: GitHub API client
+- `@anthropic-ai/claude-code`: Claude Code package
+- `js-yaml`: YAML front-matter processing
+- `marked`: Markdown parsing
+- `lodash`: Utility functions
+
+### GitHub permissions required
+
+- `contents: write`: For creating branches and files
+- `pull-requests: write`: For creating PRs
+- `issues: write`: For adding labels and assignees
+- `metadata: read`: For reading repository metadata
+
+## Success criteria
+
+1. ✅ Workflow triggers correctly on PR merge
+2. ✅ Accurately detects and filters Markdown files
+3. ✅ Successfully translates content via Claude Code
+4. ✅ Properly modifies front matter and adds translation banner
+5. ✅ Creates PR with correct metadata (reviewers, labels, projects) and reference to original PR
+6. ✅ Handles errors gracefully without breaking
+7. ✅ Maintains translation quality and Markdown structure
+8. ✅ Processes multiple files efficiently
+
+## Implementation phases
+
+### Phase 1: Core workflow
+
+- Basic file detection and filtering
+- Claude Code integration
+- Simple translation without advanced features
+
+### Phase 2: Metadata replication
+
+- PR metadata extraction
+- Reviewer/assignee assignment
+- Label and project replication
+
+### Phase 3: Advanced processing
+
+- Front-matter manipulation
+- Translation banner insertion
+- Anchor link fixing
+
+### Phase 4: Polish and testing
+- Error handling improvements
+- Comprehensive testing
+- Documentation and examples

--- a/auto-translate-markdown-claude/package-lock.json
+++ b/auto-translate-markdown-claude/package-lock.json
@@ -1,0 +1,1679 @@
+{
+  "name": "auto-translate-markdown",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "auto-translate-markdown",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@actions/core": "^1.10.1",
+        "@actions/github": "^6.0.0",
+        "@anthropic-ai/claude-code": "^1.0.0",
+        "js-yaml": "^4.1.0",
+        "lodash": "^4.17.21",
+        "marked": "^12.0.0"
+      },
+      "devDependencies": {
+        "chai": "^5.1.1",
+        "mocha": "^10.4.0",
+        "nock": "^13.5.4",
+        "sinon": "^18.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@actions/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-hXJCSrkwfA46Vd9Z3q4cpEpHB1rL5NG04+/rbqW9d3+CSvtB1tYe8UTpAlixa1vj0m/ULglfEK2UKxMGxCxv5A==",
+      "license": "MIT",
+      "dependencies": {
+        "@actions/exec": "^1.1.1",
+        "@actions/http-client": "^2.0.1"
+      }
+    },
+    "node_modules/@actions/exec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-1.1.1.tgz",
+      "integrity": "sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w==",
+      "license": "MIT",
+      "dependencies": {
+        "@actions/io": "^1.0.1"
+      }
+    },
+    "node_modules/@actions/github": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@actions/github/-/github-6.0.1.tgz",
+      "integrity": "sha512-xbZVcaqD4XnQAe35qSQqskb3SqIAfRyLBrHMd/8TuL7hJSz2QtbDwnNM8zWx4zO5l2fnGtseNE3MbEvD7BxVMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@actions/http-client": "^2.2.0",
+        "@octokit/core": "^5.0.1",
+        "@octokit/plugin-paginate-rest": "^9.2.2",
+        "@octokit/plugin-rest-endpoint-methods": "^10.4.0",
+        "@octokit/request": "^8.4.1",
+        "@octokit/request-error": "^5.1.1",
+        "undici": "^5.28.5"
+      }
+    },
+    "node_modules/@actions/http-client": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.2.3.tgz",
+      "integrity": "sha512-mx8hyJi/hjFvbPokCg4uRd4ZX78t+YyRPtnKWwIl+RzNaVuFpQHfmlGVfsKEJN8LwTCvL+DfVgAM04XaHkm6bA==",
+      "license": "MIT",
+      "dependencies": {
+        "tunnel": "^0.0.6",
+        "undici": "^5.25.4"
+      }
+    },
+    "node_modules/@actions/io": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.3.tgz",
+      "integrity": "sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q==",
+      "license": "MIT"
+    },
+    "node_modules/@anthropic-ai/claude-code": {
+      "version": "1.0.35",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-1.0.35.tgz",
+      "integrity": "sha512-rQr03moVxUZSR9hZGHXatjukxmgK9VoihiVG/lkUWFb6NDxhG+EZB+jSY2gtTsxJwnE1pQciLvOPVI/UxXo4TA==",
+      "hasInstallScript": true,
+      "license": "SEE LICENSE IN README.md",
+      "bin": {
+        "claude": "cli.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "^0.33.5",
+        "@img/sharp-darwin-x64": "^0.33.5",
+        "@img/sharp-linux-arm": "^0.33.5",
+        "@img/sharp-linux-arm64": "^0.33.5",
+        "@img/sharp-linux-x64": "^0.33.5",
+        "@img/sharp-win32-x64": "^0.33.5"
+      }
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
+      "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
+      "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
+      "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
+      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
+      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
+      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
+      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
+      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.0.5"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
+      "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
+      "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
+      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@octokit/auth-token": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
+      "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/core": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.1.tgz",
+      "integrity": "sha512-dKYCMuPO1bmrpuogcjQ8z7ICCH3FP6WmxpwC03yjzGfZhj9fTJg6+bS1+UAplekbN2C+M61UNllGOOoAfGCrdQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-token": "^4.0.0",
+        "@octokit/graphql": "^7.1.0",
+        "@octokit/request": "^8.4.1",
+        "@octokit/request-error": "^5.1.1",
+        "@octokit/types": "^13.0.0",
+        "before-after-hook": "^2.2.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/endpoint": {
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.6.tgz",
+      "integrity": "sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^13.1.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/graphql": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.1.1.tgz",
+      "integrity": "sha512-3mkDltSfcDUoa176nlGoA32RGjeWjl3K7F/BwHwRMJUW/IteSa4bnSV8p2ThNkcIcZU2umkZWxwETSSCJf2Q7g==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/request": "^8.4.1",
+        "@octokit/types": "^13.0.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-paginate-rest": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-9.2.2.tgz",
+      "integrity": "sha512-u3KYkGF7GcZnSD/3UP0S7K5XUFT2FkOQdcfXZGZQPGv3lm4F2Xbf71lvjldr8c1H3nNbF+33cLEkWYbokGWqiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^12.6.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": "5"
+      }
+    },
+    "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/openapi-types": {
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
+      "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/types": {
+      "version": "12.6.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
+      "integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^20.0.0"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-10.4.1.tgz",
+      "integrity": "sha512-xV1b+ceKV9KytQe3zCVqjg+8GTGfDYwaT1ATU5isiUyVtlVAO3HNdzpS4sr4GBx4hxQ46s7ITtZrAsxG22+rVg==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^12.6.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": "5"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/openapi-types": {
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
+      "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/types": {
+      "version": "12.6.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
+      "integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^20.0.0"
+      }
+    },
+    "node_modules/@octokit/request": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.4.1.tgz",
+      "integrity": "sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/endpoint": "^9.0.6",
+        "@octokit/request-error": "^5.1.1",
+        "@octokit/types": "^13.1.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.1.1.tgz",
+      "integrity": "sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^13.1.0",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^24.2.0"
+      }
+    },
+    "node_modules/@sinonjs/commons": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "11.2.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-11.2.2.tgz",
+      "integrity": "sha512-G2piCSxQ7oWOxwGSAyFHfPIsyeJGXYtc6mFbnFA+kRXkiEnTl8c/8jul2S329iFBnDI9HGoeWWAZvuvOkZccgw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/@sinonjs/samsam": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.2.tgz",
+      "integrity": "sha512-v46t/fwnhejRSFTGqbpn9u+LQ9xJDse10gNnPgAcxgdoCDMXj/G2asWAC/8Qs+BAZDicX+MNZouXT1A7c83kVw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.1.0"
+      }
+    },
+    "node_modules/@sinonjs/samsam/node_modules/type-detect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@sinonjs/text-encoding": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.3.tgz",
+      "integrity": "sha512-DE427ROAphMQzU4ENbliGYrBSYPXF+TtLg9S8vzeA+OF4ZKzoDdzfL8sxuMUGS/lgRhM6j1URSk9ghf7Xo1tyA==",
+      "dev": true,
+      "license": "(Unlicense OR Apache-2.0)"
+    },
+    "node_modules/ansi-colors": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/before-after-hook": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
+      "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.2.0.tgz",
+      "integrity": "sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
+      "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decamelize": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/deprecation": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
+      "license": "ISC"
+    },
+    "node_modules/diff": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
+      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "bin": {
+        "flat": "cli.js"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/just-extend": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-6.2.0.tgz",
+      "integrity": "sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "deprecated": "This package is deprecated. Use the optional chaining (?.) operator instead.",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.4.tgz",
+      "integrity": "sha512-wJzkKwJrheKtknCOKNEtDK4iqg/MxmZheEMtSTYvnzRdEYaZzmgH976nenp8WdJRdx5Vc1X/9MO0Oszl6ezeXg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/marked": {
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-12.0.2.tgz",
+      "integrity": "sha512-qXUm7e/YKFoqFPYPa3Ukg9xlI5cyAtGmyEIzMfW//m6kXwCy2Ps9DYf5ioijFKQ8qyuscrHoY04iJGctu2Kg0Q==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/mocha": {
+      "version": "10.8.2",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.8.2.tgz",
+      "integrity": "sha512-VZlYo/WE8t1tstuRmqgeyBgCbJc/lEdopaa+axcKzTBJ+UIdlAB9XnmvTCAH4pwR4ElNInaedhEBmZD8iCSVEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-colors": "^4.1.3",
+        "browser-stdout": "^1.3.1",
+        "chokidar": "^3.5.3",
+        "debug": "^4.3.5",
+        "diff": "^5.2.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-up": "^5.0.0",
+        "glob": "^8.1.0",
+        "he": "^1.2.0",
+        "js-yaml": "^4.1.0",
+        "log-symbols": "^4.1.0",
+        "minimatch": "^5.1.6",
+        "ms": "^2.1.3",
+        "serialize-javascript": "^6.0.2",
+        "strip-json-comments": "^3.1.1",
+        "supports-color": "^8.1.1",
+        "workerpool": "^6.5.1",
+        "yargs": "^16.2.0",
+        "yargs-parser": "^20.2.9",
+        "yargs-unparser": "^2.0.0"
+      },
+      "bin": {
+        "_mocha": "bin/_mocha",
+        "mocha": "bin/mocha.js"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nise": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-6.1.1.tgz",
+      "integrity": "sha512-aMSAzLVY7LyeM60gvBS423nBmIPP+Wy7St7hsb+8/fc1HmeoHJfLO8CKse4u3BtOZvQLJghYPI2i/1WZrEj5/g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "@sinonjs/fake-timers": "^13.0.1",
+        "@sinonjs/text-encoding": "^0.7.3",
+        "just-extend": "^6.2.0",
+        "path-to-regexp": "^8.1.0"
+      }
+    },
+    "node_modules/nise/node_modules/@sinonjs/fake-timers": {
+      "version": "13.0.5",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-13.0.5.tgz",
+      "integrity": "sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1"
+      }
+    },
+    "node_modules/nock": {
+      "version": "13.5.6",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.5.6.tgz",
+      "integrity": "sha512-o2zOYiCpzRqSzPj0Zt/dQ/DqZeYoaQ7TUonc/xUPjCGl9WeHpNbxgVvOquXYAaJzI0M9BXV3HTzG0p8IUAbBTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "propagate": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
+      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/serialize-javascript": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "randombytes": "^2.1.0"
+      }
+    },
+    "node_modules/sinon": {
+      "version": "18.0.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-18.0.1.tgz",
+      "integrity": "sha512-a2N2TDY1uGviajJ6r4D1CyRAkzE9NNVlYOV1wX5xQDuAk0ONgzgRl0EjCQuRCPxOwp13ghsMwt9Gdldujs39qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "@sinonjs/fake-timers": "11.2.2",
+        "@sinonjs/samsam": "^8.0.0",
+        "diff": "^5.2.0",
+        "nise": "^6.0.0",
+        "supports-color": "^7"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/sinon"
+      }
+    },
+    "node_modules/sinon/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/undici": {
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "node_modules/universal-user-agent": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
+      "integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==",
+      "license": "ISC"
+    },
+    "node_modules/workerpool": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.5.1.tgz",
+      "integrity": "sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs-unparser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "camelcase": "^6.0.0",
+        "decamelize": "^4.0.0",
+        "flat": "^5.0.2",
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/auto-translate-markdown-claude/package.json
+++ b/auto-translate-markdown-claude/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "auto-translate-markdown",
+  "version": "1.0.0",
+  "description": "GitHub Actions workflow to automatically translate Markdown files to Japanese using Claude Code",
+  "main": "scripts/translate-markdown.js",
+  "scripts": {
+    "test": "node tests/run-tests.js",
+    "test:unit": "node tests/unit-tests.js",
+    "test:integration": "node tests/integration-test.js",
+    "test:local": "node tests/local-test.js",
+    "dev:setup": "node tests/setup-dev-env.js"
+  },
+  "keywords": [
+    "github-actions",
+    "claude-code",
+    "translation",
+    "markdown",
+    "japanese",
+    "automation"
+  ],
+  "author": "GitHub Actions",
+  "license": "MIT",
+  "dependencies": {
+    "@actions/core": "^1.10.1",
+    "@actions/github": "^6.0.0",
+    "@anthropic-ai/claude-code": "^1.0.0",
+    "js-yaml": "^4.1.0",
+    "marked": "^12.0.0",
+    "lodash": "^4.17.21"
+  },
+  "devDependencies": {
+    "chai": "^5.1.1",
+    "mocha": "^10.4.0",
+    "nock": "^13.5.4",
+    "sinon": "^18.0.0"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  }
+}

--- a/auto-translate-markdown-claude/sample-usage.md
+++ b/auto-translate-markdown-claude/sample-usage.md
@@ -1,0 +1,405 @@
+# Sample Usage Configuration for Auto-Translate Markdown
+
+This file shows example configurations for different repository setups.
+
+## Basic Configuration
+
+For calling this workflow from another repository:
+
+```yaml
+# .github/workflows/auto-translate-markdown.yml
+name: Auto-Translate Markdown to Japanese
+
+on:
+  pull_request:
+    types: [closed]
+    paths:
+      - 'docs/en-us/**/*.md'
+      - 'docs/en-us/**/*.mdx'
+
+jobs:
+  translate-markdown:
+    if: github.event.pull_request.merged == true
+    uses: josh-wong/actions/.github/workflows/auto-translate-markdown-claude-reusable.yml@main
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+### Alternative: Self-contained workflow
+
+If you want to copy the workflow files directly to your repository:
+
+```yaml
+# .github/workflows/auto-translate-markdown.yml
+name: Auto-Translate Markdown to Japanese
+
+on:
+  pull_request:
+    types: [closed]
+    paths:
+      - 'docs/en-us/**/*.md'
+      - 'docs/en-us/**/*.mdx'
+
+jobs:
+  translate-markdown:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+          
+      - uses: actions/checkout@v4
+        with:
+          repository: josh-wong/actions
+          path: .actions
+          
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+      
+      - name: Run translation
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          REPOSITORY_OWNER: ${{ github.repository_owner }}
+          REPOSITORY_NAME: ${{ github.event.repository.name }}
+        run: |
+          cd .actions/auto-translate-markdown-claude
+          npm install
+          npm install -g @anthropic-ai/claude-code
+          node scripts/translate-markdown.js
+```
+
+## Usage Options
+
+### Option 1: Reusable Workflow (Recommended)
+- ✅ **Easier to maintain**: Updates happen automatically when the source workflow is updated
+- ✅ **Cleaner**: Minimal configuration in your repository
+- ✅ **Centralized**: All logic stays in the actions repository
+
+### Option 2: Self-contained Workflow
+- ✅ **Full control**: You can modify the workflow for your specific needs
+- ✅ **No dependencies**: Works even if the source repository is unavailable
+- ❌ **Maintenance overhead**: You need to manually update when improvements are made
+```
+
+## Advanced Configuration
+
+For repositories with multiple documentation sections:
+
+```javascript
+// translate-markdown.js configuration
+this.config = {
+  targetLanguage: 'ja-jp',
+  sidebarMapping: {
+    'docsEnglish': 'docsJapanese',
+    'apiEnglish': 'apiJapanese',
+    'guidesEnglish': 'guidesJapanese',
+    'tutorialsEnglish': 'tutorialsJapanese'
+  },
+  translationBannerPath: '/src/components/_translation-ja-jp.mdx',
+  fileExtensions: ['.md', '.mdx', '.markdown'],
+  excludePaths: [
+    'docs/ja-jp',
+    'docs/internal',
+    'CHANGELOG.md',
+    'CONTRIBUTING.md'
+  ],
+  maxFileSize: 100000, // 100KB limit
+  batchSize: 5 // Process 5 files at a time
+};
+```
+
+## Multi-Language Support
+
+To support multiple target languages:
+
+```javascript
+// Multi-language configuration example
+const configs = {
+  'ja-jp': {
+    targetLanguage: 'ja-jp',
+    sidebarMapping: { 'docsEnglish': 'docsJapanese' },
+    translationBannerPath: '/src/components/_translation-ja-jp.mdx',
+    branchSuffix: 'ja-jp'
+  },
+  'es-es': {
+    targetLanguage: 'es-es', 
+    sidebarMapping: { 'docsEnglish': 'docsSpanish' },
+    translationBannerPath: '/src/components/_translation-es-es.mdx',
+    branchSuffix: 'es-es'
+  },
+  'fr-fr': {
+    targetLanguage: 'fr-fr',
+    sidebarMapping: { 'docsEnglish': 'docsFrench' },
+    translationBannerPath: '/src/components/_translation-fr-fr.mdx', 
+    branchSuffix: 'fr-fr'
+  }
+};
+```
+
+## Repository Secrets Setup
+
+Required secrets in repository settings:
+
+```bash
+# GitHub repository secrets
+ANTHROPIC_API_KEY=sk-ant-api03-...  # Your Anthropic API key
+
+# Optional: Enhanced GitHub token for enterprise features
+GH_ENTERPRISE_TOKEN=ghp_...         # GitHub Enterprise token (if needed)
+```
+
+## File Structure Examples
+
+### Nextra Documentation Site
+
+```
+docs/
+├── getting-started.md              # English source
+├── api/
+│   ├── authentication.md
+│   └── endpoints.mdx
+├── ja-jp/                          # Japanese translations
+│   ├── getting-started.md
+│   └── api/
+│       ├── authentication.md
+│       └── endpoints.mdx
+└── _meta.json                      # Nextra navigation
+```
+
+### Docusaurus Site
+
+```markdown
+docs/
+├── intro.md                        # English source
+├── tutorial-basics/
+│   ├── create-a-page.md
+│   └── deploy-your-site.md
+├── ja-jp/                          # Japanese translations
+│   ├── intro.md
+│   └── tutorial-basics/
+│       ├── create-a-page.md
+│       └── deploy-your-site.md
+└── sidebars.js                     # Docusaurus sidebar config
+```
+
+## Translation Banner Examples
+
+### Basic Banner (MDX)
+
+```markdown
+import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
+
+<TranslationBanner />
+```
+
+### Advanced Banner with Links
+
+```markdown
+import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
+
+<TranslationBanner />
+```
+
+## Conditional Workflow Triggers
+
+### Development vs Production
+
+```yaml
+# Only run on main branch merges
+on:
+  pull_request:
+    types: [closed]
+    branches: [main, master]
+    paths: ['docs/**/*.md', 'docs/**/*.mdx']
+
+# Or run on specific labels
+on:
+  pull_request:
+    types: [closed, labeled]
+
+jobs:
+  translate-markdown:
+    if: |
+      github.event.pull_request.merged == true &&
+      contains(github.event.pull_request.labels.*.name, 'translate')
+```
+
+### Path-based Filtering
+
+```yaml
+# Only translate specific directories
+on:
+  pull_request:
+    types: [closed]
+    paths:
+      - 'docs/guides/**/*.md'
+      - 'docs/api/**/*.mdx'
+      - '!docs/internal/**'        # Exclude internal docs
+      - '!docs/ja-jp/**'           # Exclude existing translations
+```
+
+## Error Handling Examples
+
+### Graceful Failure
+
+```javascript
+// Enhanced error handling in translate-markdown.js
+async run() {
+  try {
+    await this.executeWorkflow();
+  } catch (error) {
+    await this.handleFailure(error);
+    // Don't re-throw to prevent workflow failure
+  }
+}
+
+async handleFailure(error) {
+  // Log detailed error
+  console.error('Translation workflow failed:', error);
+  
+  // Comment on original PR
+  await this.octokit.rest.issues.createComment({
+    issue_number: this.config.prNumber,
+    body: this.generateErrorComment(error)
+  });
+  
+  // Send notification (optional)
+  await this.notifyMaintainers(error);
+}
+```
+
+### Partial Success Handling
+
+```javascript
+// Handle partial translation success
+async translateFiles(filePaths) {
+  const results = {
+    successful: [],
+    failed: []
+  };
+  
+  for (const filePath of filePaths) {
+    try {
+      await this.translateSingleFile(filePath);
+      results.successful.push(filePath);
+    } catch (error) {
+      results.failed.push({ filePath, error: error.message });
+    }
+  }
+  
+  if (results.successful.length > 0) {
+    await this.createPartialTranslationPR(results);
+  }
+  
+  return results;
+}
+```
+
+## Performance Optimization
+
+### Batch Processing
+
+```javascript
+// Process files in batches to avoid rate limits
+async translateFilesBatch(filePaths, batchSize = 3) {
+  const batches = [];
+  for (let i = 0; i < filePaths.length; i += batchSize) {
+    batches.push(filePaths.slice(i, i + batchSize));
+  }
+  
+  const results = [];
+  for (const batch of batches) {
+    const batchResults = await Promise.allSettled(
+      batch.map(file => this.translateSingleFile(file))
+    );
+    results.push(...batchResults);
+    
+    // Wait between batches to respect rate limits
+    await this.sleep(2000);
+  }
+  
+  return results;
+}
+```
+
+### Caching Strategy
+
+```javascript
+// Cache translations to avoid re-translating unchanged content
+const crypto = require('crypto');
+
+class TranslationCache {
+  generateContentHash(content) {
+    return crypto.createHash('sha256').update(content).digest('hex');
+  }
+  
+  async getCachedTranslation(contentHash) {
+    // Check if translation exists in cache
+    // Could use GitHub cache, filesystem, or external service
+  }
+  
+  async setCachedTranslation(contentHash, translation) {
+    // Store translation in cache
+  }
+}
+```
+
+## Testing and Validation
+
+### Local Testing Script
+
+```bash
+#!/bin/bash
+# test-translation.sh
+
+# Set up test environment
+export ANTHROPIC_API_KEY="your-test-api-key"
+export GITHUB_TOKEN="your-test-token"
+export PR_NUMBER="123"
+export PR_TITLE="Test Translation"
+export PR_AUTHOR="testuser"
+export PR_HEAD_REF="test-branch"
+export REPOSITORY_OWNER="testorg"
+export REPOSITORY_NAME="testrepo"
+
+# Create test markdown file
+echo "# Test Document
+This is a test document for translation.
+
+## Section 1
+Some content here.
+
+[Link to section](#section-1)
+" > test-doc.md
+
+# Run translation
+cd auto-translate-markdown
+npm install
+node translate-markdown.js
+
+echo "Translation test completed!"
+```
+
+### Validation Checklist
+
+- [ ] Front matter properly updated
+- [ ] Translation banner added
+- [ ] Anchor links working
+- [ ] Code blocks preserved
+- [ ] File structure correct
+- [ ] PR metadata applied
+- [ ] Error handling works
+- [ ] Rate limiting respected
+
+This configuration guide should help you customize the auto-translation workflow for your specific repository needs!

--- a/auto-translate-markdown-claude/scripts/anchor-link-fixer.js
+++ b/auto-translate-markdown-claude/scripts/anchor-link-fixer.js
@@ -1,0 +1,210 @@
+class AnchorLinkFixer {
+  constructor() {
+    this.anchorLinkRegex = /\[([^\]]*)\]\(#([^)]+)\)/g;
+    this.headingRegex = /^(#{1,6})\s+(.+)$/;
+  }
+
+  fixAnchorLinks(translatedContent, originalContent) {
+    console.log('🔗 Fixing anchor links in translated content...');
+    
+    if (!translatedContent || !originalContent) {
+      console.warn('⚠️ Missing content for anchor link fixing');
+      return translatedContent;
+    }
+
+    try {
+      // Extract headings from both original and translated content
+      const originalHeadings = this.extractHeadings(originalContent);
+      const translatedHeadings = this.extractHeadings(translatedContent);
+      
+      // Create mapping between original and translated anchors
+      const anchorMap = this.createAnchorMapping(originalHeadings, translatedHeadings);
+      
+      console.log(`📊 Found ${Object.keys(anchorMap).length} anchor mappings`);
+      
+      // Replace anchor links in translated content
+      const fixedContent = this.replaceAnchorLinks(translatedContent, anchorMap);
+      
+      console.log('✅ Anchor links fixed successfully');
+      return fixedContent;
+      
+    } catch (error) {
+      console.error('❌ Failed to fix anchor links:', error.message);
+      return translatedContent; // Return original if fixing fails
+    }
+  }
+
+  extractHeadings(content) {
+    const headings = [];
+    const lines = content.split('\n');
+    
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i].trim();
+      const match = line.match(this.headingRegex);
+      
+      if (match) {
+        const [, hashes, text] = match;
+        const level = hashes.length;
+        const anchor = this.generateAnchor(text);
+        
+        headings.push({
+          level,
+          text: text.trim(),
+          anchor,
+          lineNumber: i
+        });
+      }
+    }
+    
+    return headings;
+  }
+
+  generateAnchor(text) {
+    // Generate GitHub-style anchor links
+    return text
+      .toLowerCase()
+      .trim()
+      // Remove markdown formatting
+      .replace(/\*\*([^*]+)\*\*/g, '$1') // Bold
+      .replace(/\*([^*]+)\*/g, '$1')     // Italic
+      .replace(/`([^`]+)`/g, '$1')       // Code
+      .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1') // Links
+      // Replace special characters and spaces
+      .replace(/[^\w\s\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FAF-]/g, '') // Keep word chars, spaces, and Japanese
+      .replace(/\s+/g, '-')              // Replace spaces with hyphens
+      .replace(/-+/g, '-')               // Replace multiple hyphens with single
+      .replace(/^-|-$/g, '');            // Remove leading/trailing hyphens
+  }
+
+  createAnchorMapping(originalHeadings, translatedHeadings) {
+    const anchorMap = {};
+    
+    // Try to match headings by level and position
+    for (let i = 0; i < originalHeadings.length && i < translatedHeadings.length; i++) {
+      const original = originalHeadings[i];
+      const translated = translatedHeadings[i];
+      
+      // Map if the levels match (assuming structure is preserved)
+      if (original.level === translated.level) {
+        anchorMap[original.anchor] = translated.anchor;
+      }
+    }
+    
+    // Fallback: try to match by similar content structure
+    this.addFallbackMappings(originalHeadings, translatedHeadings, anchorMap);
+    
+    return anchorMap;
+  }
+
+  addFallbackMappings(originalHeadings, translatedHeadings, anchorMap) {
+    // For headings not yet mapped, try to find matches by level
+    const unmappedOriginal = originalHeadings.filter(h => !anchorMap[h.anchor]);
+    const unmappedTranslated = translatedHeadings.filter(h => 
+      !Object.values(anchorMap).includes(h.anchor)
+    );
+    
+    // Group by level for better matching
+    const originalByLevel = this.groupHeadingsByLevel(unmappedOriginal);
+    const translatedByLevel = this.groupHeadingsByLevel(unmappedTranslated);
+    
+    // Match within each level
+    for (const level of Object.keys(originalByLevel)) {
+      const originals = originalByLevel[level] || [];
+      const translated = translatedByLevel[level] || [];
+      
+      const maxLength = Math.min(originals.length, translated.length);
+      for (let i = 0; i < maxLength; i++) {
+        anchorMap[originals[i].anchor] = translated[i].anchor;
+      }
+    }
+  }
+
+  groupHeadingsByLevel(headings) {
+    return headings.reduce((groups, heading) => {
+      const level = heading.level;
+      if (!groups[level]) {
+        groups[level] = [];
+      }
+      groups[level].push(heading);
+      return groups;
+    }, {});
+  }
+
+  replaceAnchorLinks(content, anchorMap) {
+    return content.replace(this.anchorLinkRegex, (match, linkText, anchor) => {
+      const mappedAnchor = anchorMap[anchor];
+      
+      if (mappedAnchor) {
+        console.log(`🔄 Mapped anchor: #${anchor} → #${mappedAnchor}`);
+        return `[${linkText}](#${mappedAnchor})`;
+      } else {
+        console.warn(`⚠️ No mapping found for anchor: #${anchor}`);
+        return match; // Keep original if no mapping found
+      }
+    });
+  }
+
+  // Helper method to validate anchor links
+  validateAnchorLinks(content) {
+    const issues = [];
+    const headings = this.extractHeadings(content);
+    const headingAnchors = new Set(headings.map(h => h.anchor));
+    
+    // Find all anchor links
+    const anchorLinks = [];
+    let match;
+    while ((match = this.anchorLinkRegex.exec(content)) !== null) {
+      anchorLinks.push({
+        text: match[1],
+        anchor: match[2],
+        fullMatch: match[0]
+      });
+    }
+    
+    // Check if each anchor link has a corresponding heading
+    for (const link of anchorLinks) {
+      if (!headingAnchors.has(link.anchor)) {
+        issues.push(`Broken anchor link: ${link.fullMatch}`);
+      }
+    }
+    
+    return issues;
+  }
+
+  // Helper method to get anchor link statistics
+  getAnchorLinkStats(content) {
+    const headings = this.extractHeadings(content);
+    const anchorLinks = [];
+    
+    let match;
+    while ((match = this.anchorLinkRegex.exec(content)) !== null) {
+      anchorLinks.push(match[2]);
+    }
+    
+    return {
+      totalHeadings: headings.length,
+      totalAnchorLinks: anchorLinks.length,
+      uniqueAnchors: new Set(anchorLinks).size,
+      headingLevels: headings.reduce((levels, h) => {
+        levels[h.level] = (levels[h.level] || 0) + 1;
+        return levels;
+      }, {})
+    };
+  }
+
+  // Helper method to preview anchor mapping
+  previewAnchorMapping(originalContent, translatedContent) {
+    const originalHeadings = this.extractHeadings(originalContent);
+    const translatedHeadings = this.extractHeadings(translatedContent);
+    const anchorMap = this.createAnchorMapping(originalHeadings, translatedHeadings);
+    
+    console.log('\n📋 Anchor Mapping Preview:');
+    for (const [original, translated] of Object.entries(anchorMap)) {
+      console.log(`  ${original} → ${translated}`);
+    }
+    
+    return anchorMap;
+  }
+}
+
+module.exports = AnchorLinkFixer;

--- a/auto-translate-markdown-claude/scripts/claude-code-translator.js
+++ b/auto-translate-markdown-claude/scripts/claude-code-translator.js
@@ -1,0 +1,157 @@
+const { execSync } = require('child_process');
+const fs = require('fs').promises;
+const path = require('path');
+
+class ClaudeCodeTranslator {
+  constructor() {
+    this.maxRetries = 3;
+    this.retryDelay = 1000; // 1 second
+  }
+
+  async translateMarkdown(content, filePath) {
+    console.log(`🔤 Translating content using Claude Code...`);
+    
+    const prompt = this.buildTranslationPrompt(content, filePath);
+    
+    for (let attempt = 1; attempt <= this.maxRetries; attempt++) {
+      try {
+        console.log(`🔄 Translation attempt ${attempt}/${this.maxRetries}`);
+        
+        const result = await this.callClaudeCode(prompt);
+        
+        if (result && result.translatedContent) {
+          console.log('✅ Translation successful');
+          return result.translatedContent;
+        }
+        
+        throw new Error('No translated content returned from Claude Code');
+        
+      } catch (error) {
+        console.error(`❌ Translation attempt ${attempt} failed:`, error.message);
+        
+        if (attempt === this.maxRetries) {
+          throw new Error(`Translation failed after ${this.maxRetries} attempts: ${error.message}`);
+        }
+        
+        // Wait before retrying
+        await this.sleep(this.retryDelay * attempt);
+      }
+    }
+  }
+
+  buildTranslationPrompt(content, filePath) {
+    return `Translate this Markdown content from English to Japanese:
+
+REQUIREMENTS:
+- Preserve ALL Markdown formatting exactly
+- Do NOT translate code blocks, URLs, file paths, or technical commands  
+- Keep front matter YAML unchanged
+- Use natural, professional Japanese
+- Preserve document structure exactly
+
+Content:
+${content}
+
+Return only the translated markdown:`;
+  }
+
+  async callClaudeCode(prompt) {
+    try {
+      // Create a temporary file for the prompt to avoid command line length limits
+      const tempFile = path.join(process.cwd(), '.translation-prompt.txt');
+      await fs.writeFile(tempFile, prompt, 'utf8');
+      
+      // Call Claude Code with the prompt file
+      const command = `cat "${tempFile}" | claude -p --output-format json --max-turns 1 --dangerously-skip-permissions`;
+      
+      console.log('🤖 Calling Claude Code...');
+      const output = execSync(command, { 
+        encoding: 'utf8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+        timeout: 60000 // 60 second timeout
+      });
+      
+      // Clean up temp file
+      await fs.unlink(tempFile).catch(() => {}); // Ignore cleanup errors
+      
+      // Parse the JSON response
+      const response = JSON.parse(output);
+      
+      if (response.is_error) {
+        throw new Error(`Claude Code error: ${response.result || 'Unknown error'}`);
+      }
+      
+      // Extract the actual result content
+      let resultContent = response.result || '';
+      
+      // Clean up any unwanted preamble or wrapper content
+      if (resultContent.includes('```markdown')) {
+        // Extract content from markdown code block if present
+        const match = resultContent.match(/```markdown\n([\s\S]*?)\n```/);
+        if (match && match[1]) {
+          resultContent = match[1];
+        }
+      }
+      
+      // Remove any instructional preamble
+      const lines = resultContent.split('\n');
+      const startIndex = lines.findIndex(line => line.startsWith('---') || line.startsWith('#'));
+      if (startIndex > 0) {
+        resultContent = lines.slice(startIndex).join('\n');
+      }
+      
+      if (!resultContent || resultContent.trim() === '') {
+        throw new Error('No translated content returned from Claude Code');
+      }
+      
+      return {
+        translatedContent: resultContent.trim(),
+        headingMap: {} // We'll extract headings separately if needed
+      };
+      
+    } catch (error) {
+      if (error.code === 'ENOENT') {
+        throw new Error('Claude Code CLI not found. Please ensure it is installed and in PATH.');
+      }
+      
+      if (error.signal === 'SIGTERM') {
+        throw new Error('Claude Code translation timed out');
+      }
+      
+      throw new Error(`Claude Code execution failed: ${error.message}`);
+    }
+  }
+
+  async sleep(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+  }
+
+  // Helper method to validate Claude Code installation
+  static async validateInstallation() {
+    try {
+      execSync('claude --version', { stdio: 'pipe' });
+      return true;
+    } catch (error) {
+      return false;
+    }
+  }
+
+  // Helper method to test authentication
+  static async testAuthentication() {
+    try {
+      const testCommand = `echo "test" | claude -p --output-format json --max-turns 1`;
+      const output = execSync(testCommand, { 
+        encoding: 'utf8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+        timeout: 10000
+      });
+      
+      const response = JSON.parse(output);
+      return !response.is_error;
+    } catch (error) {
+      return false;
+    }
+  }
+}
+
+module.exports = ClaudeCodeTranslator;

--- a/auto-translate-markdown-claude/scripts/file-processor.js
+++ b/auto-translate-markdown-claude/scripts/file-processor.js
@@ -1,0 +1,209 @@
+const yaml = require('js-yaml');
+
+class FileProcessor {
+  constructor() {
+    this.frontMatterRegex = /^---\s*\n([\s\S]*?)\n---\s*\n([\s\S]*)$/;
+  }
+
+  extractFrontMatter(content) {
+    console.log('📋 Extracting front matter...');
+    
+    const match = content.match(this.frontMatterRegex);
+    
+    if (match) {
+      try {
+        const frontMatterYaml = match[1];
+        const body = match[2];
+        const frontMatter = yaml.load(frontMatterYaml);
+        
+        console.log('✅ Front matter extracted successfully');
+        return { frontMatter, body, hasFrontMatter: true };
+      } catch (error) {
+        console.warn('⚠️ Failed to parse front matter YAML:', error.message);
+        return { frontMatter: {}, body: content, hasFrontMatter: false };
+      }
+    }
+    
+    console.log('ℹ️ No front matter found');
+    return { frontMatter: {}, body: content, hasFrontMatter: false };
+  }
+
+  updateFrontMatter(frontMatter, sidebarMapping) {
+    console.log('🔧 Updating front matter...');
+    
+    if (!frontMatter || typeof frontMatter !== 'object') {
+      console.log('ℹ️ No front matter to update');
+      return frontMatter;
+    }
+
+    const updated = { ...frontMatter };
+    
+    // Update displayed_sidebar mapping
+    if (updated.displayed_sidebar && sidebarMapping[updated.displayed_sidebar]) {
+      const oldValue = updated.displayed_sidebar;
+      updated.displayed_sidebar = sidebarMapping[oldValue];
+      console.log(`📝 Updated displayed_sidebar: "${oldValue}" → "${updated.displayed_sidebar}"`);
+    }
+    
+    // Add translation metadata
+    updated.translated = true;
+    updated.translation_source = 'claude-code';
+    updated.translation_date = new Date().toISOString().split('T')[0];
+    
+    console.log('✅ Front matter updated');
+    return updated;
+  }
+
+  addTranslationBanner(content, bannerPath) {
+    console.log('🏷️ Adding translation banner...');
+    
+    if (!content || typeof content !== 'string') {
+      console.warn('⚠️ Invalid content for banner insertion');
+      return content;
+    }
+
+    const bannerImport = `import TranslationBanner from '${bannerPath}';`;
+    const bannerComponent = '\n<TranslationBanner />\n';
+    
+    // Find the first heading (title) to insert banner after it
+    const lines = content.split('\n');
+    let titleLineIndex = -1;
+    
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i].trim();
+      if (line.startsWith('# ')) {
+        titleLineIndex = i;
+        break;
+      }
+    }
+    
+    if (titleLineIndex === -1) {
+      console.warn('⚠️ No title heading found, adding banner at the beginning');
+      return `${bannerImport}\n\n${bannerComponent}\n${content}`;
+    }
+    
+    // Insert import at the beginning and banner after title
+    const beforeTitle = lines.slice(0, titleLineIndex + 1);
+    const afterTitle = lines.slice(titleLineIndex + 1);
+    
+    const result = [
+      bannerImport,
+      '',
+      ...beforeTitle,
+      bannerComponent,
+      ...afterTitle
+    ].join('\n');
+    
+    console.log('✅ Translation banner added');
+    return result;
+  }
+
+  reassembleFile(frontMatter, body) {
+    console.log('🔗 Reassembling file...');
+    
+    if (!frontMatter || Object.keys(frontMatter).length === 0) {
+      console.log('ℹ️ No front matter to include');
+      return body;
+    }
+    
+    try {
+      const frontMatterYaml = yaml.dump(frontMatter, {
+        lineWidth: -1, // Don't wrap lines
+        noRefs: true,   // Don't use references
+        sortKeys: false // Preserve key order
+      });
+      
+      const result = `---\n${frontMatterYaml}---\n${body}`;
+      console.log('✅ File reassembled successfully');
+      return result;
+    } catch (error) {
+      console.error('❌ Failed to serialize front matter:', error.message);
+      return body;
+    }
+  }
+
+  // Helper method to validate markdown structure
+  validateMarkdown(content) {
+    const issues = [];
+    
+    // Check for basic markdown structure
+    if (!content || typeof content !== 'string') {
+      issues.push('Content is not a valid string');
+      return issues;
+    }
+    
+    // Check for unmatched code blocks
+    const codeBlockMatches = content.match(/```/g);
+    if (codeBlockMatches && codeBlockMatches.length % 2 !== 0) {
+      issues.push('Unmatched code block delimiters');
+    }
+    
+    // Check for malformed links
+    const linkRegex = /\[([^\]]*)\]\(([^)]*)\)/g;
+    let match;
+    while ((match = linkRegex.exec(content)) !== null) {
+      const [, text, url] = match;
+      if (!text.trim()) {
+        issues.push('Empty link text found');
+      }
+      if (!url.trim()) {
+        issues.push('Empty link URL found');
+      }
+    }
+    
+    return issues;
+  }
+
+  // Helper method to extract headings
+  extractHeadings(content) {
+    const headings = [];
+    const lines = content.split('\n');
+    
+    for (const line of lines) {
+      const trimmed = line.trim();
+      const match = trimmed.match(/^(#{1,6})\s+(.+)$/);
+      if (match) {
+        const [, hashes, text] = match;
+        headings.push({
+          level: hashes.length,
+          text: text,
+          anchor: this.generateAnchor(text)
+        });
+      }
+    }
+    
+    return headings;
+  }
+
+  // Helper method to generate anchor links from heading text
+  generateAnchor(text) {
+    return text
+      .toLowerCase()
+      .replace(/[^\w\s-]/g, '') // Remove special characters
+      .replace(/\s+/g, '-')     // Replace spaces with hyphens
+      .trim();
+  }
+
+  // Helper method to count words (useful for translation metrics)
+  countWords(content) {
+    if (!content || typeof content !== 'string') {
+      return 0;
+    }
+    
+    // Remove code blocks first
+    const withoutCodeBlocks = content.replace(/```[\s\S]*?```/g, '');
+    
+    // Remove inline code
+    const withoutInlineCode = withoutCodeBlocks.replace(/`[^`]*`/g, '');
+    
+    // Count words
+    const words = withoutInlineCode
+      .replace(/[^\w\s]/g, ' ')
+      .split(/\s+/)
+      .filter(word => word.length > 0);
+    
+    return words.length;
+  }
+}
+
+module.exports = FileProcessor;

--- a/auto-translate-markdown-claude/scripts/pr-metadata-extractor.js
+++ b/auto-translate-markdown-claude/scripts/pr-metadata-extractor.js
@@ -1,0 +1,210 @@
+class PRMetadataExtractor {
+  constructor(octokit) {
+    this.octokit = octokit;
+  }
+
+  async extractMetadata(prNumber) {
+    console.log(`📋 Extracting metadata for PR #${prNumber}...`);
+    
+    try {
+      // Get PR details
+      const { data: pr } = await this.octokit.rest.pulls.get({
+        owner: process.env.REPOSITORY_OWNER,
+        repo: process.env.REPOSITORY_NAME,
+        pull_number: prNumber
+      });
+
+      // Get PR reviews to extract reviewers
+      const { data: reviews } = await this.octokit.rest.pulls.listReviews({
+        owner: process.env.REPOSITORY_OWNER,
+        repo: process.env.REPOSITORY_NAME,
+        pull_number: prNumber
+      });
+
+      // Get requested reviewers
+      const { data: requestedReviewers } = await this.octokit.rest.pulls.listRequestedReviewers({
+        owner: process.env.REPOSITORY_OWNER,
+        repo: process.env.REPOSITORY_NAME,
+        pull_number: prNumber
+      });
+
+      const metadata = {
+        title: pr.title,
+        body: pr.body,
+        author: pr.user.login,
+        branch: pr.head.ref,
+        labels: pr.labels.map(label => label.name),
+        reviewers: this.extractReviewers(reviews, requestedReviewers),
+        assignees: pr.assignees.map(assignee => assignee.login),
+        milestone: pr.milestone ? pr.milestone.title : null,
+        projects: [], // Will be populated separately if needed
+        createdAt: pr.created_at,
+        mergedAt: pr.merged_at
+      };
+
+      console.log('✅ PR metadata extracted successfully');
+      console.log(`📊 Found ${metadata.reviewers.length} reviewers, ${metadata.labels.length} labels`);
+      
+      return metadata;
+    } catch (error) {
+      console.error('❌ Failed to extract PR metadata:', error.message);
+      
+      // Return minimal metadata to continue workflow
+      return {
+        title: process.env.PR_TITLE || 'Unknown',
+        body: process.env.PR_BODY || '',
+        author: process.env.PR_AUTHOR || 'unknown',
+        branch: process.env.PR_HEAD_REF || 'unknown',
+        labels: [],
+        reviewers: [],
+        assignees: [],
+        milestone: null,
+        projects: [],
+        createdAt: null,
+        mergedAt: null
+      };
+    }
+  }
+
+  extractReviewers(reviews, requestedReviewers) {
+    const reviewers = new Set();
+    
+    // Add users who actually reviewed
+    reviews.forEach(review => {
+      if (review.user && review.user.login) {
+        reviewers.add(review.user.login);
+      }
+    });
+    
+    // Add users who were requested to review
+    requestedReviewers.users.forEach(user => {
+      if (user.login) {
+        reviewers.add(user.login);
+      }
+    });
+    
+    // Convert Set to Array and filter out bots and the PR author
+    return Array.from(reviewers).filter(reviewer => {
+      return reviewer !== process.env.PR_AUTHOR && 
+             !reviewer.includes('[bot]') &&
+             reviewer !== 'github-actions[bot]';
+    });
+  }
+
+  async extractProjectsMetadata(prNumber) {
+    console.log(`📋 Extracting projects metadata for PR #${prNumber}...`);
+    
+    try {
+      // Note: GitHub's Projects API is more complex and varies between 
+      // classic projects and new projects (beta). This is a simplified version.
+      
+      // Get repository projects (classic projects)
+      const { data: repoProjects } = await this.octokit.rest.projects.listForRepo({
+        owner: process.env.REPOSITORY_OWNER,
+        repo: process.env.REPOSITORY_NAME
+      });
+
+      // For now, we'll return empty array since project association 
+      // is complex and varies by project type
+      console.log(`ℹ️ Found ${repoProjects.length} repository projects`);
+      return [];
+      
+    } catch (error) {
+      console.warn('⚠️ Could not extract projects metadata:', error.message);
+      return [];
+    }
+  }
+
+  async getCommitMetadata(prNumber) {
+    console.log(`📋 Extracting commit metadata for PR #${prNumber}...`);
+    
+    try {
+      const { data: commits } = await this.octokit.rest.pulls.listCommits({
+        owner: process.env.REPOSITORY_OWNER,
+        repo: process.env.REPOSITORY_NAME,
+        pull_number: prNumber
+      });
+
+      return {
+        totalCommits: commits.length,
+        firstCommit: commits[0],
+        lastCommit: commits[commits.length - 1],
+        authors: [...new Set(commits.map(commit => commit.author?.login).filter(Boolean))]
+      };
+    } catch (error) {
+      console.warn('⚠️ Could not extract commit metadata:', error.message);
+      return {
+        totalCommits: 0,
+        firstCommit: null,
+        lastCommit: null,
+        authors: []
+      };
+    }
+  }
+
+  async getFileChangeStats(prNumber) {
+    console.log(`📊 Getting file change statistics for PR #${prNumber}...`);
+    
+    try {
+      const { data: prDetails } = await this.octokit.rest.pulls.get({
+        owner: process.env.REPOSITORY_OWNER,
+        repo: process.env.REPOSITORY_NAME,
+        pull_number: prNumber
+      });
+
+      return {
+        totalChanges: prDetails.changed_files,
+        additions: prDetails.additions,
+        deletions: prDetails.deletions,
+        changedFiles: prDetails.changed_files
+      };
+    } catch (error) {
+      console.warn('⚠️ Could not get file change stats:', error.message);
+      return {
+        totalChanges: 0,
+        additions: 0,
+        deletions: 0,
+        changedFiles: 0
+      };
+    }
+  }
+
+  // Helper method to filter metadata for security
+  sanitizeMetadata(metadata) {
+    // Remove any potentially sensitive information
+    const sanitized = { ...metadata };
+    
+    // Remove email addresses from body text
+    if (sanitized.body) {
+      sanitized.body = sanitized.body.replace(/\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b/g, '[email]');
+    }
+    
+    // Remove tokens or keys that might be in the content
+    if (sanitized.body) {
+      sanitized.body = sanitized.body.replace(/\b[A-Za-z0-9]{20,}\b/g, '[token]');
+    }
+    
+    return sanitized;
+  }
+
+  // Helper method to validate metadata completeness
+  validateMetadata(metadata) {
+    const issues = [];
+    
+    if (!metadata.title) {
+      issues.push('Missing PR title');
+    }
+    
+    if (!metadata.author) {
+      issues.push('Missing PR author');
+    }
+    
+    if (!metadata.branch) {
+      issues.push('Missing branch name');
+    }
+    
+    return issues;
+  }
+}
+
+module.exports = PRMetadataExtractor;

--- a/auto-translate-markdown-claude/scripts/translate-markdown.js
+++ b/auto-translate-markdown-claude/scripts/translate-markdown.js
@@ -1,0 +1,351 @@
+#!/usr/bin/env node
+
+const core = require('@actions/core');
+const github = require('@actions/github');
+const fs = require('fs').promises;
+const path = require('path');
+const { execSync } = require('child_process');
+
+const ClaudeCodeTranslator = require('./claude-code-translator');
+const FileProcessor = require('./file-processor');
+const PRMetadataExtractor = require('./pr-metadata-extractor');
+const AnchorLinkFixer = require('./anchor-link-fixer');
+
+class MarkdownTranslationWorkflow {
+  constructor() {
+    this.octokit = github.getOctokit(process.env.GITHUB_TOKEN);
+    this.context = github.context;
+    this.translator = new ClaudeCodeTranslator();
+    this.fileProcessor = new FileProcessor();
+    this.prMetadataExtractor = new PRMetadataExtractor(this.octokit);
+    this.anchorLinkFixer = new AnchorLinkFixer();
+    
+    // Configuration from environment.
+    this.config = {
+      prNumber: parseInt(process.env.PR_NUMBER),
+      prTitle: process.env.PR_TITLE,
+      prBody: process.env.PR_BODY,
+      prAuthor: process.env.PR_AUTHOR,
+      prHeadRef: process.env.PR_HEAD_REF,
+      repositoryOwner: process.env.REPOSITORY_OWNER,
+      repositoryName: process.env.REPOSITORY_NAME,
+      targetLanguage: 'ja-jp',
+      sidebarMapping: {
+        'docsEnglish': 'docsJapanese'
+      },
+      translationBannerPath: '/src/components/_translation-ja-jp.mdx',
+      fileExtensions: ['.md', '.mdx']
+    };
+  }
+
+  async run() {
+    try {
+      console.log('🚀 Starting auto-translate Markdown workflow...');
+      
+      // Step 1: Detect and filter Markdown files.
+      const changedFiles = await this.detectMarkdownFiles();
+      console.log(`📁 Found ${changedFiles.length} Markdown files to translate`);
+      
+      if (changedFiles.length === 0) {
+        console.log('✅ No files to translate. Exiting...');
+        return;
+      }
+
+      // Step 2: Extract PR metadata.
+      const prMetadata = await this.prMetadataExtractor.extractMetadata(this.config.prNumber);
+      console.log('📋 Extracted PR metadata');
+
+      // Step 3: Create translation branch.
+      const translationBranch = await this.createTranslationBranch();
+      console.log(`🌿 Created translation branch: ${translationBranch}`);
+
+      // Step 4: Process and translate files.
+      const translatedFiles = await this.translateFiles(changedFiles);
+      console.log(`📝 Translated ${translatedFiles.length} files`);
+
+      // Step 5: Create pull request.
+      await this.createTranslationPR(translationBranch, translatedFiles, prMetadata);
+      console.log('🎉 Translation workflow completed successfully!');
+
+    } catch (error) {
+      console.error('❌ Translation workflow failed:', error);
+      core.setFailed(error.message);
+      throw error;
+    }
+  }
+
+  async detectMarkdownFiles() {
+    console.log('🔍 Detecting changed Markdown files...');
+    
+    // Get list of changed files from the merged PR.
+    const { data: prFiles } = await this.octokit.rest.pulls.listFiles({
+      owner: this.config.repositoryOwner,
+      repo: this.config.repositoryName,
+      pull_number: this.config.prNumber
+    });
+
+    const markdownFiles = prFiles.filter(file => {
+      // Filter for .md and .mdx files.
+      const hasValidExtension = this.config.fileExtensions.some(ext => 
+        file.filename.endsWith(ext)
+      );
+      
+      // Exclude files in docs/ja-jp directories.
+      const isInJapaneseDir = file.filename.includes('docs/ja-jp');
+      
+      // Only process added or modified files (not deleted).
+      const isAddedOrModified = ['added', 'modified'].includes(file.status);
+      
+      return hasValidExtension && !isInJapaneseDir && isAddedOrModified;
+    });
+
+    console.log(`📊 Filtered ${markdownFiles.length} files from ${prFiles.length} total changed files`);
+    return markdownFiles.map(file => file.filename);
+  }
+
+  async createTranslationBranch() {
+    const branchName = `${this.config.prHeadRef}-ja-jp`;
+    console.log(`🌿 Creating translation branch: ${branchName}`);
+
+    try {
+      // Get the latest commit SHA from main/master.
+      const { data: mainBranch } = await this.octokit.rest.repos.getBranch({
+        owner: this.config.repositoryOwner,
+        repo: this.config.repositoryName,
+        branch: 'main'
+      });
+
+      // Create new branch.
+      await this.octokit.rest.git.createRef({
+        owner: this.config.repositoryOwner,
+        repo: this.config.repositoryName,
+        ref: `refs/heads/${branchName}`,
+        sha: mainBranch.commit.sha
+      });
+
+      // Checkout the new branch locally.
+      execSync(`git checkout -b ${branchName}`, { stdio: 'inherit' });
+      
+      return branchName;
+    } catch (error) {
+      if (error.status === 422) {
+        console.log(`⚠️ Branch ${branchName} already exists, checking it out...`);
+        execSync(`git checkout ${branchName}`, { stdio: 'inherit' });
+        return branchName;
+      }
+      throw error;
+    }
+  }
+
+  async translateFiles(filePaths) {
+    console.log(`📝 Starting translation of ${filePaths.length} files...`);
+    const translatedFiles = [];
+
+    for (const filePath of filePaths) {
+      try {
+        console.log(`🔄 Processing: ${filePath}`);
+        
+        // Read the original file.
+        const content = await fs.readFile(filePath, 'utf8');
+        
+        // Generate Japanese file path.
+        const japaneseFilePath = this.generateJapaneseFilePath(filePath);
+        
+        // Process the file (extract front matter, translate, modify).
+        const processedContent = await this.processFile(content, filePath);
+        
+        // Ensure directory exists.
+        await fs.mkdir(path.dirname(japaneseFilePath), { recursive: true });
+        
+        // Write the translated file.
+        await fs.writeFile(japaneseFilePath, processedContent, 'utf8');
+        
+        // Stage the file for commit.
+        execSync(`git add "${japaneseFilePath}"`, { stdio: 'inherit' });
+        
+        translatedFiles.push({
+          originalPath: filePath,
+          translatedPath: japaneseFilePath
+        });
+        
+        console.log(`✅ Translated: ${filePath} → ${japaneseFilePath}`);
+        
+      } catch (error) {
+        console.error(`❌ Failed to translate ${filePath}:`, error);
+        // Continue with other files instead of failing completely.
+      }
+    }
+
+    // Commit all translated files.
+    if (translatedFiles.length > 0) {
+      const commitMessage = `feat: add Japanese translations\n\nAuto-translated from PR #${this.config.prNumber}: ${this.config.prTitle}`;
+      execSync(`git commit -m "${commitMessage}"`, { stdio: 'inherit' });
+      execSync(`git push origin HEAD`, { stdio: 'inherit' });
+    }
+
+    return translatedFiles;
+  }
+
+  generateJapaneseFilePath(originalPath) {
+    // Convert path like "docs/guides/getting-started.md" to "docs/ja-jp/guides/getting-started.md".
+    const pathParts = originalPath.split('/');
+    
+    // Find the docs directory and insert ja-jp after it.
+    const docsIndex = pathParts.findIndex(part => part === 'docs');
+    if (docsIndex !== -1) {
+      pathParts.splice(docsIndex + 1, 0, 'ja-jp');
+    } else {
+      // If no docs directory, create one.
+      pathParts.unshift('docs', 'ja-jp');
+    }
+    
+    return pathParts.join('/');
+  }
+
+  async processFile(content, filePath) {
+    console.log(`🔧 Processing file: ${filePath}`);
+    
+    // Step 1: Extract and parse front matter.
+    const { frontMatter, body } = this.fileProcessor.extractFrontMatter(content);
+    
+    // Step 2: Translate the main content.
+    const translatedBody = await this.translator.translateMarkdown(body, filePath);
+    
+    // Step 3: Update front matter.
+    const updatedFrontMatter = this.fileProcessor.updateFrontMatter(
+      frontMatter, 
+      this.config.sidebarMapping
+    );
+    
+    // Step 4: Add translation banner.
+    const bodyWithBanner = this.fileProcessor.addTranslationBanner(
+      translatedBody, 
+      this.config.translationBannerPath
+    );
+    
+    // Step 5: Fix anchor links.
+    const finalBody = this.anchorLinkFixer.fixAnchorLinks(bodyWithBanner, body);
+    
+    // Step 6: Reassemble the file.
+    return this.fileProcessor.reassembleFile(updatedFrontMatter, finalBody);
+  }
+
+  async createTranslationPR(branchName, translatedFiles, prMetadata) {
+    console.log('📤 Creating translation pull request...');
+    
+    const prTitle = `🌐 Japanese translations for PR #${this.config.prNumber}`;
+    const prBody = this.generatePRBody(translatedFiles, prMetadata);
+    
+    try {
+      // Create the pull request.
+      const { data: newPR } = await this.octokit.rest.pulls.create({
+        owner: this.config.repositoryOwner,
+        repo: this.config.repositoryName,
+        title: prTitle,
+        body: prBody,
+        head: branchName,
+        base: 'main'
+      });
+
+      console.log(`📋 Created PR #${newPR.number}: ${newPR.html_url}`);
+
+      // Apply metadata (labels, reviewers, assignees, projects).
+      await this.applyPRMetadata(newPR.number, prMetadata);
+      
+      return newPR;
+    } catch (error) {
+      console.error('❌ Failed to create translation PR:', error);
+      throw error;
+    }
+  }
+
+  generatePRBody(translatedFiles, prMetadata) {
+    const fileList = translatedFiles
+      .map(file => `- \`${file.translatedPath}\` (from \`${file.originalPath}\`)`)
+      .join('\n');
+
+    return `## 🌐 Japanese translation
+
+This PR contains automatic Japanese translations generated from the content merged in PR #${this.config.prNumber}.
+
+### 📁 Translated files
+
+${fileList}
+
+### 🔗 Source
+
+- **Original PR:** #${this.config.prNumber} - ${this.config.prTitle}
+- **Author:** @${this.config.prAuthor}
+- **Branch:** \`${this.config.prHeadRef}\`
+
+### 🤖 Translation details
+
+- **Target language:** Japanese (ja-jp)
+- **Translation method:** Claude Code (Anthropic)
+- **Translation banner:** Added to all translated files
+- **Sidebar:** Updated from "docsEnglish" to "docsJapanese"
+- **Anchor links:** Updated to match Japanese headings
+
+### ✅ Review checklist
+
+- [ ] Translation accuracy and natural Japanese phrasing
+- [ ] Technical terminology consistency
+- [ ] Link functionality (especially anchor links)
+- [ ] Front matter configuration
+- [ ] Translation banner placement
+
+---
+*This translation was automatically generated. Please review for accuracy and naturalness.*`;
+  }
+
+  async applyPRMetadata(prNumber, metadata) {
+    console.log('🏷️ Applying PR metadata...');
+    
+    try {
+      // Add "documentation" label.
+      const labels = [...(metadata.labels || []), 'documentation'];
+      await this.octokit.rest.issues.addLabels({
+        owner: this.config.repositoryOwner,
+        repo: this.config.repositoryName,
+        issue_number: prNumber,
+        labels: labels
+      });
+
+      // Add reviewers (if any from original PR).
+      if (metadata.reviewers && metadata.reviewers.length > 0) {
+        await this.octokit.rest.pulls.requestReviewers({
+          owner: this.config.repositoryOwner,
+          repo: this.config.repositoryName,
+          pull_number: prNumber,
+          reviewers: metadata.reviewers
+        });
+      }
+
+      // Add assignee (original PR author).
+      if (this.config.prAuthor) {
+        await this.octokit.rest.issues.addAssignees({
+          owner: this.config.repositoryOwner,
+          repo: this.config.repositoryName,
+          issue_number: prNumber,
+          assignees: [this.config.prAuthor]
+        });
+      }
+
+      console.log('✅ Applied PR metadata successfully');
+    } catch (error) {
+      console.error('⚠️ Failed to apply some PR metadata:', error);
+      // Don't fail the entire workflow for metadata issues.
+    }
+  }
+}
+
+// Run the workflow.
+if (require.main === module) {
+  const workflow = new MarkdownTranslationWorkflow();
+  workflow.run().catch(error => {
+    console.error('💥 Workflow execution failed:', error);
+    process.exit(1);
+  });
+}
+
+module.exports = MarkdownTranslationWorkflow;

--- a/auto-translate-markdown-claude/tests/integration-test.js
+++ b/auto-translate-markdown-claude/tests/integration-test.js
@@ -1,0 +1,253 @@
+#!/usr/bin/env node
+
+const fs = require('fs').promises;
+const path = require('path');
+const { execSync } = require('child_process');
+
+console.log('🧪 Running Local Integration Test...\n');
+
+class LocalTester {
+  constructor() {
+    this.testDir = path.join(__dirname, 'temp');
+    this.originalEnv = { ...process.env };
+  }
+
+  async setup() {
+    console.log('🔧 Setting up test environment...');
+    
+    // Create temporary test directory
+    try {
+      await fs.mkdir(this.testDir, { recursive: true });
+    } catch (error) {
+      // Directory might already exist
+    }
+
+    // Set required environment variables for testing
+    process.env.GITHUB_TOKEN = 'test-token';
+    process.env.ANTHROPIC_API_KEY = 'test-api-key';
+    process.env.PR_NUMBER = '123';
+    process.env.PR_TITLE = 'Test PR';
+    process.env.PR_BODY = 'Test PR body';
+    process.env.PR_AUTHOR = 'testuser';
+    process.env.PR_HEAD_REF = 'feature/test';
+    process.env.REPOSITORY_OWNER = 'testowner';
+    process.env.REPOSITORY_NAME = 'testrepo';
+
+    console.log('✅ Test environment ready');
+  }
+
+  async createTestFiles() {
+    console.log('📝 Creating test Markdown files...');
+
+    const testContent = `---
+title: Getting Started Guide
+displayed_sidebar: docsEnglish
+description: Learn how to get started
+---
+
+# Getting Started
+
+Welcome to our documentation! This guide will help you get started quickly.
+
+## Prerequisites
+
+Before you begin, make sure you have:
+
+- Node.js installed
+- A GitHub account
+- Basic knowledge of Markdown
+
+## Installation
+
+Follow these steps:
+
+1. Clone the repository
+2. Install dependencies
+3. Run the application
+
+### Step 1: Clone
+
+\`\`\`bash
+git clone https://github.com/example/repo.git
+\`\`\`
+
+### Step 2: Install
+
+\`\`\`bash
+npm install
+\`\`\`
+
+## Features
+
+Our platform offers:
+
+- [Real-time collaboration](#collaboration)
+- Advanced analytics
+- Custom integrations
+
+### Collaboration
+
+Work together seamlessly with your team.
+
+## Next Steps
+
+Check out our [API documentation](./api.md) for more details.
+`;
+
+    const testFiles = [
+      { path: 'docs/guides/getting-started.md', content: testContent },
+      { path: 'docs/api/reference.mdx', content: testContent.replace('Getting Started', 'API Reference') },
+      { path: 'README.md', content: '# Test Project\n\nThis is a test project.' }
+    ];
+
+    for (const file of testFiles) {
+      const fullPath = path.join(this.testDir, file.path);
+      await fs.mkdir(path.dirname(fullPath), { recursive: true });
+      await fs.writeFile(fullPath, file.content);
+    }
+
+    console.log(`✅ Created ${testFiles.length} test files`);
+    return testFiles.map(f => f.path);
+  }
+
+  async testFileProcessing() {
+    console.log('🔄 Testing file processing...');
+
+    const FileProcessor = require('../scripts/file-processor');
+    const AnchorLinkFixer = require('../scripts/anchor-link-fixer');
+    
+    const fileProcessor = new FileProcessor();
+    const anchorFixer = new AnchorLinkFixer();
+
+    const testFile = path.join(this.testDir, 'docs/guides/getting-started.md');
+    const content = await fs.readFile(testFile, 'utf8');
+
+    // Test front matter extraction
+    const { frontMatter, body } = fileProcessor.extractFrontMatter(content);
+    console.log('  ✅ Front matter extracted successfully');
+
+    // Test front matter updates
+    const updatedFrontMatter = fileProcessor.updateFrontMatter(frontMatter, {
+      'docsEnglish': 'docsJapanese'
+    });
+    console.log('  ✅ Front matter updated successfully');
+
+    // Test translation banner addition
+    const bodyWithBanner = fileProcessor.addTranslationBanner(
+      body, 
+      '/src/components/_translation-ja-jp.mdx'
+    );
+    console.log('  ✅ Translation banner added successfully');
+
+    // Test file reassembly
+    const reassembled = fileProcessor.reassembleFile(updatedFrontMatter, bodyWithBanner);
+    console.log('  ✅ File reassembled successfully');
+
+    // Write test output
+    const outputPath = path.join(this.testDir, 'docs/ja-jp/guides/getting-started.md');
+    await fs.mkdir(path.dirname(outputPath), { recursive: true });
+    await fs.writeFile(outputPath, reassembled);
+    console.log('  ✅ Test output file created');
+
+    return true;
+  }
+
+  async testClaudeCodeMock() {
+    console.log('🤖 Testing Claude Code integration (mock)...');
+
+    // Mock Claude Code translator
+    class MockClaudeCodeTranslator {
+      async translateMarkdown(content, filePath) {
+        console.log(`  📝 Mock translating: ${filePath}`);
+        
+        // Simple mock translation - replace common words
+        const mockTranslated = content
+          .replace(/# Getting Started/g, '# はじめに')
+          .replace(/## Prerequisites/g, '## 前提条件')
+          .replace(/## Installation/g, '## インストール')
+          .replace(/## Features/g, '## 機能')
+          .replace(/### Collaboration/g, '### コラボレーション')
+          .replace(/## Next Steps/g, '## 次のステップ')
+          .replace(/Welcome to our documentation!/g, 'ドキュメントへようこそ！')
+          .replace(/This guide will help you get started quickly\./g, 'このガイドでは、すぐに開始できるようにサポートします。');
+
+        return mockTranslated;
+      }
+    }
+
+    const translator = new MockClaudeCodeTranslator();
+    const testContent = '# Getting Started\n\nWelcome to our documentation!';
+    
+    const translated = await translator.translateMarkdown(testContent, 'test.md');
+    
+    if (translated.includes('はじめに') && translated.includes('ドキュメントへようこそ')) {
+      console.log('  ✅ Mock translation working correctly');
+      return true;
+    } else {
+      throw new Error('Mock translation failed');
+    }
+  }
+
+  async testGitOperations() {
+    console.log('🔧 Testing Git operations (dry run)...');
+
+    try {
+      // Test git commands that would be used (but don't actually execute)
+      const gitCommands = [
+        'git status',
+        'git branch --show-current',
+        'git log --oneline -1'
+      ];
+
+      for (const cmd of gitCommands) {
+        console.log(`  🔍 Would run: ${cmd}`);
+      }
+
+      console.log('  ✅ Git operations test passed (dry run)');
+      return true;
+    } catch (error) {
+      console.log('  ⚠️ Git operations test skipped (no git repo)');
+      return true; // Not a failure for testing
+    }
+  }
+
+  async cleanup() {
+    console.log('🧹 Cleaning up test environment...');
+    
+    try {
+      await fs.rm(this.testDir, { recursive: true, force: true });
+      console.log('  ✅ Test files cleaned up');
+    } catch (error) {
+      console.log('  ⚠️ Cleanup warning:', error.message);
+    }
+
+    // Restore original environment
+    process.env = this.originalEnv;
+    console.log('  ✅ Environment restored');
+  }
+
+  async run() {
+    try {
+      await this.setup();
+      await this.createTestFiles();
+      await this.testFileProcessing();
+      await this.testClaudeCodeMock();
+      await this.testGitOperations();
+      
+      console.log('\n🎉 Local integration test completed successfully!');
+      
+    } catch (error) {
+      console.error('\n❌ Local integration test failed:', error.message);
+      throw error;
+    } finally {
+      await this.cleanup();
+    }
+  }
+}
+
+// Run the test
+const tester = new LocalTester();
+tester.run().catch(error => {
+  console.error('Integration test failed:', error);
+  process.exit(1);
+});

--- a/auto-translate-markdown-claude/tests/local-test.js
+++ b/auto-translate-markdown-claude/tests/local-test.js
@@ -1,0 +1,295 @@
+#!/usr/bin/env node
+
+const fs = require('fs').promises;
+const path = require('path');
+
+console.log('🔬 Running Local Workflow Test...\n');
+
+class LocalWorkflowTester {
+  constructor() {
+    this.testData = {
+      prNumber: 123,
+      prTitle: 'Add new documentation',
+      prBody: 'This PR adds comprehensive documentation for the new features.',
+      prAuthor: 'testuser',
+      prHeadRef: 'feature/docs',
+      repositoryOwner: 'testowner',
+      repositoryName: 'testrepo'
+    };
+  }
+
+  async testWorkflowComponents() {
+    console.log('🧩 Testing individual workflow components...\n');
+
+    // Test 1: File detection logic
+    await this.testFileDetection();
+    
+    // Test 2: File processing pipeline
+    await this.testFileProcessing();
+    
+    // Test 3: Translation logic (mocked)
+    await this.testTranslationLogic();
+    
+    // Test 4: PR body generation
+    await this.testPRBodyGeneration();
+    
+    console.log('✅ All component tests passed!\n');
+  }
+
+  async testFileDetection() {
+    console.log('🔍 Testing file detection...');
+    
+    const mockPRFiles = [
+      { filename: 'docs/guide.md', status: 'modified' },
+      { filename: 'docs/api.mdx', status: 'added' },
+      { filename: 'docs/ja-jp/existing.md', status: 'modified' },
+      { filename: 'README.md', status: 'modified' },
+      { filename: 'package.json', status: 'modified' },
+      { filename: 'src/component.jsx', status: 'added' },
+      { filename: 'deleted.md', status: 'removed' }
+    ];
+
+    const fileExtensions = ['.md', '.mdx'];
+    const filteredFiles = mockPRFiles.filter(file => {
+      const hasValidExtension = fileExtensions.some(ext => file.filename.endsWith(ext));
+      const isInJapaneseDir = file.filename.includes('docs/ja-jp');
+      const isAddedOrModified = ['added', 'modified'].includes(file.status);
+      
+      return hasValidExtension && !isInJapaneseDir && isAddedOrModified;
+    });
+
+    console.log(`  📊 Found ${filteredFiles.length} eligible files:`);
+    filteredFiles.forEach(file => {
+      console.log(`    - ${file.filename} (${file.status})`);
+    });
+
+    if (filteredFiles.length !== 3) {
+      throw new Error(`Expected 3 files, got ${filteredFiles.length}`);
+    }
+
+    console.log('  ✅ File detection working correctly\n');
+  }
+
+  async testFileProcessing() {
+    console.log('📝 Testing file processing pipeline...');
+
+    const sampleContent = `---
+title: Getting Started
+displayed_sidebar: docsEnglish
+description: Learn the basics
+---
+
+# Getting Started
+
+Welcome to our platform! This guide covers:
+
+## Prerequisites
+
+- Node.js 18+
+- Git knowledge
+- [GitHub account](https://github.com)
+
+## Quick Start
+
+1. Clone the repository
+2. Install dependencies: \`npm install\`
+3. Start development: \`npm run dev\`
+
+### Advanced Configuration
+
+Check our [configuration guide](#configuration) for details.
+
+## Next Steps
+
+Visit the [API documentation](./api.md) to learn more.
+`;
+
+    // Mock our processors
+    const FileProcessor = require('../scripts/file-processor');
+    const AnchorLinkFixer = require('../scripts/anchor-link-fixer');
+    
+    const fileProcessor = new FileProcessor();
+    const anchorFixer = new AnchorLinkFixer();
+
+    // Test front matter extraction
+    const { frontMatter, body } = fileProcessor.extractFrontMatter(sampleContent);
+    console.log('  ✅ Front matter extracted');
+
+    // Test sidebar mapping
+    const updatedFrontMatter = fileProcessor.updateFrontMatter(frontMatter, {
+      'docsEnglish': 'docsJapanese'
+    });
+    console.log(`  ✅ Sidebar updated: ${frontMatter.displayed_sidebar} → ${updatedFrontMatter.displayed_sidebar}`);
+
+    // Test translation banner
+    const withBanner = fileProcessor.addTranslationBanner(body, '/src/components/_translation-ja-jp.mdx');
+    console.log('  ✅ Translation banner added');
+
+    // Test reassembly
+    const reassembled = fileProcessor.reassembleFile(updatedFrontMatter, withBanner);
+    console.log('  ✅ File reassembled successfully\n');
+  }
+
+  async testTranslationLogic() {
+    console.log('🤖 Testing translation logic (mock)...');
+
+    // Mock translation that simulates Claude Code
+    const mockTranslate = (content) => {
+      return content
+        .replace(/# Getting Started/g, '# はじめに')
+        .replace(/## Prerequisites/g, '## 前提条件')
+        .replace(/## Quick Start/g, '## クイックスタート')
+        .replace(/### Advanced Configuration/g, '### 高度な設定')
+        .replace(/## Next Steps/g, '## 次のステップ')
+        .replace(/Welcome to our platform!/g, 'プラットフォームへようこそ！')
+        .replace(/This guide covers:/g, 'このガイドでは以下を説明します：')
+        .replace(/Clone the repository/g, 'リポジトリをクローン')
+        .replace(/Install dependencies/g, '依存関係をインストール')
+        .replace(/Start development/g, '開発を開始');
+    };
+
+    const originalText = '# Getting Started\n\nWelcome to our platform! This guide covers:\n\n## Prerequisites';
+    const translatedText = mockTranslate(originalText);
+    
+    console.log('  📝 Original:', originalText.split('\n')[0]);
+    console.log('  🌐 Translated:', translatedText.split('\n')[0]);
+    
+    if (translatedText.includes('はじめに') && translatedText.includes('プラットフォームへようこそ')) {
+      console.log('  ✅ Mock translation working correctly\n');
+    } else {
+      throw new Error('Mock translation failed');
+    }
+  }
+
+  async testPRBodyGeneration() {
+    console.log('📋 Testing PR body generation...');
+
+    const translatedFiles = [
+      { originalPath: 'docs/guide.md', translatedPath: 'docs/ja-jp/guide.md' },
+      { originalPath: 'README.md', translatedPath: 'docs/ja-jp/README.md' }
+    ];
+
+    const prBody = this.generatePRBody(translatedFiles);
+    
+    console.log('  📄 Generated PR body preview:');
+    console.log('  ' + '─'.repeat(50));
+    console.log(prBody.split('\n').slice(0, 10).map(line => `  ${line}`).join('\n'));
+    console.log('  ' + '─'.repeat(50));
+    
+    // Verify key elements
+    const checks = [
+      { name: 'Contains file list', test: prBody.includes('docs/ja-jp/guide.md') },
+      { name: 'References original PR', test: prBody.includes('#123') },
+      { name: 'Shows author', test: prBody.includes('@testuser') },
+      { name: 'Shows branch', test: prBody.includes('feature/docs') },
+      { name: 'Has review checklist', test: prBody.includes('Review checklist') }
+    ];
+
+    checks.forEach(check => {
+      if (check.test) {
+        console.log(`  ✅ ${check.name}`);
+      } else {
+        throw new Error(`PR body missing: ${check.name}`);
+      }
+    });
+
+    console.log('  ✅ PR body generation working correctly\n');
+  }
+
+  generatePRBody(translatedFiles) {
+    const fileList = translatedFiles
+      .map(file => `- \`${file.translatedPath}\` (from \`${file.originalPath}\`)`)
+      .join('\n');
+
+    return `## 🌐 Japanese translation
+
+This PR contains automatic Japanese translations generated from the content merged in PR #${this.testData.prNumber}.
+
+### 📁 Translated files
+
+${fileList}
+
+### 🔗 Source
+
+- **Original PR**: #${this.testData.prNumber} - ${this.testData.prTitle}
+- **Author**: @${this.testData.prAuthor}
+- **Branch**: \`${this.testData.prHeadRef}\`
+
+### 🤖 Translation details
+
+- **Target language**: Japanese (ja-jp)
+- **Translation method**: Claude Code (Anthropic)
+- **Translation banner**: Added to all translated files
+- **Sidebar**: Updated from "docsEnglish" to "docsJapanese"
+- **Anchor links**: Updated to match Japanese headings
+
+### ✅ Review checklist
+
+- [ ] Translation accuracy and natural Japanese phrasing
+- [ ] Technical terminology consistency
+- [ ] Link functionality (especially anchor links)
+- [ ] Front matter configuration
+- [ ] Translation banner placement
+
+---
+*This translation was automatically generated. Please review for accuracy and naturalness.*`;
+  }
+
+  async testPathGeneration() {
+    console.log('🗂️ Testing Japanese path generation...');
+
+    const testPaths = [
+      { input: 'docs/guides/getting-started.md', expected: 'docs/ja-jp/guides/getting-started.md' },
+      { input: 'docs/api/reference.mdx', expected: 'docs/ja-jp/api/reference.mdx' },
+      { input: 'README.md', expected: 'docs/ja-jp/README.md' },
+      { input: 'content/blog/post.md', expected: 'docs/ja-jp/content/blog/post.md' }
+    ];
+
+    const generateJapaneseFilePath = (originalPath) => {
+      const pathParts = originalPath.split('/');
+      const docsIndex = pathParts.findIndex(part => part === 'docs');
+      if (docsIndex !== -1) {
+        pathParts.splice(docsIndex + 1, 0, 'ja-jp');
+      } else {
+        pathParts.unshift('docs', 'ja-jp');
+      }
+      return pathParts.join('/');
+    };
+
+    testPaths.forEach(({ input, expected }) => {
+      const result = generateJapaneseFilePath(input);
+      if (result === expected) {
+        console.log(`  ✅ ${input} → ${result}`);
+      } else {
+        throw new Error(`Path generation failed: ${input} → ${result} (expected ${expected})`);
+      }
+    });
+
+    console.log('  ✅ Path generation working correctly\n');
+  }
+
+  async run() {
+    try {
+      await this.testWorkflowComponents();
+      await this.testPathGeneration();
+      
+      console.log('🎉 Local workflow test completed successfully!');
+      console.log('\n🚀 Next steps to test the full workflow:');
+      console.log('1. Set up a test repository');
+      console.log('2. Add the workflow files');
+      console.log('3. Create a PR with Markdown files');
+      console.log('4. Merge the PR and watch the workflow run');
+      
+    } catch (error) {
+      console.error('\n❌ Local workflow test failed:', error.message);
+      throw error;
+    }
+  }
+}
+
+// Run the test
+const tester = new LocalWorkflowTester();
+tester.run().catch(error => {
+  console.error('Local test failed:', error);
+  process.exit(1);
+});

--- a/auto-translate-markdown-claude/tests/run-tests.js
+++ b/auto-translate-markdown-claude/tests/run-tests.js
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+
+const { execSync } = require('child_process');
+const path = require('path');
+
+console.log('🧪 Running Auto-Translate Markdown Tests\n');
+
+const tests = [
+  { name: 'Unit Tests', command: 'npm run test:unit' },
+  { name: 'Integration Tests', command: 'npm run test:integration' },
+  { name: 'Local Workflow Test', command: 'npm run test:local' }
+];
+
+let passedTests = 0;
+let totalTests = tests.length;
+
+for (const test of tests) {
+  try {
+    console.log(`🔍 Running ${test.name}...`);
+    execSync(test.command, { stdio: 'inherit', cwd: process.cwd() });
+    console.log(`✅ ${test.name} passed\n`);
+    passedTests++;
+  } catch (error) {
+    console.error(`❌ ${test.name} failed\n`);
+  }
+}
+
+console.log('📊 Test Summary:');
+console.log(`✅ Passed: ${passedTests}/${totalTests}`);
+console.log(`❌ Failed: ${totalTests - passedTests}/${totalTests}`);
+
+if (passedTests === totalTests) {
+  console.log('\n🎉 All tests passed!');
+  process.exit(0);
+} else {
+  console.log('\n💥 Some tests failed');
+  process.exit(1);
+}

--- a/auto-translate-markdown-claude/tests/setup-dev-env.js
+++ b/auto-translate-markdown-claude/tests/setup-dev-env.js
@@ -1,0 +1,138 @@
+#!/usr/bin/env node
+
+const fs = require('fs').promises;
+const path = require('path');
+const { execSync } = require('child_process');
+
+console.log('🔧 Setting up development environment...\n');
+
+async function setupDevEnv() {
+  console.log('📋 Development Environment Setup Checklist:\n');
+
+  // Check Node.js version
+  try {
+    const nodeVersion = execSync('node --version', { encoding: 'utf8' }).trim();
+    console.log(`✅ Node.js: ${nodeVersion}`);
+    
+    const majorVersion = parseInt(nodeVersion.substring(1).split('.')[0]);
+    if (majorVersion < 18) {
+      console.log('⚠️  Warning: Node.js 18+ recommended');
+    }
+  } catch (error) {
+    console.log('❌ Node.js not found');
+  }
+
+  // Check npm
+  try {
+    const npmVersion = execSync('npm --version', { encoding: 'utf8' }).trim();
+    console.log(`✅ npm: ${npmVersion}`);
+  } catch (error) {
+    console.log('❌ npm not found');
+  }
+
+  // Check Git
+  try {
+    const gitVersion = execSync('git --version', { encoding: 'utf8' }).trim();
+    console.log(`✅ Git: ${gitVersion}`);
+  } catch (error) {
+    console.log('❌ Git not found');
+  }
+
+  // Check Claude Code CLI
+  try {
+    const claudeVersion = execSync('claude-code --version', { encoding: 'utf8' }).trim();
+    console.log(`✅ Claude Code CLI: ${claudeVersion}`);
+  } catch (error) {
+    console.log('❌ Claude Code CLI not found');
+    console.log('   Install with: npm install -g @anthropic-ai/claude-code');
+  }
+
+  console.log('\n🔐 Environment Variables Check:\n');
+
+  const requiredEnvVars = [
+    'ANTHROPIC_API_KEY',
+    'GITHUB_TOKEN'
+  ];
+
+  for (const envVar of requiredEnvVars) {
+    if (process.env[envVar]) {
+      console.log(`✅ ${envVar}: Set (${process.env[envVar].substring(0, 8)}...)`);
+    } else {
+      console.log(`❌ ${envVar}: Not set`);
+    }
+  }
+
+  console.log('\n📝 Creating example configuration files...\n');
+
+  // Create .env.example
+  const envExample = `# Copy this file to .env and fill in your values
+
+# Required: Anthropic API key for Claude Code
+ANTHROPIC_API_KEY=sk-ant-api03-...
+
+# Required: GitHub token with repo permissions
+GITHUB_TOKEN=ghp_...
+
+# For testing: Mock PR data
+PR_NUMBER=123
+PR_TITLE="Test PR Title"
+PR_BODY="Test PR body content"
+PR_AUTHOR="testuser"
+PR_HEAD_REF="feature/test-branch"
+REPOSITORY_OWNER="your-username"
+REPOSITORY_NAME="your-repo"
+`;
+
+  await fs.writeFile('.env.example', envExample);
+  console.log('✅ Created .env.example');
+
+  // Create test configuration
+  const testConfig = `{
+  "testRepo": {
+    "owner": "your-username",
+    "name": "test-repo",
+    "branch": "main"
+  },
+  "sampleFiles": [
+    {
+      "path": "docs/getting-started.md",
+      "content": "Sample markdown content for testing"
+    }
+  ],
+  "mockTranslations": {
+    "# Getting Started": "# はじめに",
+    "Welcome": "ようこそ",
+    "Installation": "インストール"
+  }
+}`;
+
+  await fs.writeFile('test/test-config.json', testConfig);
+  console.log('✅ Created test/test-config.json');
+
+  console.log('\n🚀 Quick Start Commands:\n');
+  console.log('Install dependencies:');
+  console.log('  npm install\n');
+  
+  console.log('Run tests:');
+  console.log('  npm test              # Run all tests');
+  console.log('  npm run test:unit     # Unit tests only');
+  console.log('  npm run test:local    # Local integration test\n');
+  
+  console.log('Development workflow:');
+  console.log('  1. Copy .env.example to .env and fill in your API keys');
+  console.log('  2. Run npm install to install dependencies');
+  console.log('  3. Run npm run test:local to test locally');
+  console.log('  4. Test in a real repository by triggering the workflow\n');
+
+  console.log('📚 Documentation:');
+  console.log('  - README.md: Complete setup and usage guide');
+  console.log('  - sample-usage.md: Example configurations');
+  console.log('  - test/: Test files and examples\n');
+
+  console.log('🎯 Ready to test! Run `npm test` to verify everything works.');
+}
+
+setupDevEnv().catch(error => {
+  console.error('Setup failed:', error);
+  process.exit(1);
+});

--- a/auto-translate-markdown-claude/tests/unit-tests.js
+++ b/auto-translate-markdown-claude/tests/unit-tests.js
@@ -1,0 +1,185 @@
+#!/usr/bin/env node
+
+const assert = require('assert');
+const fs = require('fs').promises;
+const path = require('path');
+
+// Import our modules for testing
+const FileProcessor = require('../scripts/file-processor');
+const AnchorLinkFixer = require('../scripts/anchor-link-fixer');
+
+console.log('🧪 Running Unit Tests...\n');
+
+class UnitTester {
+  constructor() {
+    this.tests = [];
+    this.passed = 0;
+    this.failed = 0;
+  }
+
+  test(name, testFn) {
+    this.tests.push({ name, testFn });
+  }
+
+  async run() {
+    for (const { name, testFn } of this.tests) {
+      try {
+        console.log(`  🔍 ${name}`);
+        await testFn();
+        console.log(`  ✅ ${name} passed`);
+        this.passed++;
+      } catch (error) {
+        console.log(`  ❌ ${name} failed: ${error.message}`);
+        this.failed++;
+      }
+    }
+
+    console.log(`\n📊 Unit Test Results:`);
+    console.log(`✅ Passed: ${this.passed}`);
+    console.log(`❌ Failed: ${this.failed}`);
+
+    if (this.failed > 0) {
+      process.exit(1);
+    }
+  }
+}
+
+const tester = new UnitTester();
+
+// Test FileProcessor
+tester.test('FileProcessor: Extract front matter', async () => {
+  const fileProcessor = new FileProcessor();
+  const content = `---
+title: Test Page
+displayed_sidebar: docsEnglish
+---
+
+# Test Content
+
+This is a test.`;
+
+  const { frontMatter, body } = fileProcessor.extractFrontMatter(content);
+  
+  assert.strictEqual(frontMatter.title, 'Test Page');
+  assert.strictEqual(frontMatter.displayed_sidebar, 'docsEnglish');
+  assert(body.includes('# Test Content'));
+});
+
+tester.test('FileProcessor: Update front matter', async () => {
+  const fileProcessor = new FileProcessor();
+  const frontMatter = {
+    title: 'Test Page',
+    displayed_sidebar: 'docsEnglish'
+  };
+
+  const updated = fileProcessor.updateFrontMatter(frontMatter, {
+    'docsEnglish': 'docsJapanese'
+  });
+
+  assert.strictEqual(updated.displayed_sidebar, 'docsJapanese');
+  assert.strictEqual(updated.title, 'Test Page');
+});
+
+tester.test('FileProcessor: Add translation banner', async () => {
+  const fileProcessor = new FileProcessor();
+  const body = `# Test Title
+
+Some content here.`;
+
+  const withBanner = fileProcessor.addTranslationBanner(body, '/src/components/_translation-ja-jp.mdx');
+  
+  assert(withBanner.includes('import TranslationBanner'));
+  assert(withBanner.includes('<TranslationBanner />'));
+});
+
+tester.test('FileProcessor: Reassemble file', async () => {
+  const fileProcessor = new FileProcessor();
+  const frontMatter = { title: 'Test', sidebar: 'docs' };
+  const body = '# Content';
+
+  const assembled = fileProcessor.reassembleFile(frontMatter, body);
+  
+  assert(assembled.includes('---'));
+  assert(assembled.includes('title: Test'));
+  assert(assembled.includes('# Content'));
+});
+
+// Test AnchorLinkFixer
+tester.test('AnchorLinkFixer: Fix anchor links', async () => {
+  const anchorFixer = new AnchorLinkFixer();
+  const originalBody = `# Getting Started
+
+[Link to features](#features)
+
+## Features
+
+Some content.`;
+
+  const translatedBody = `# はじめに
+
+[Link to features](#features)
+
+## 機能
+
+Some content.`;
+
+  const fixed = anchorFixer.fixAnchorLinks(translatedBody, originalBody);
+  
+  assert(fixed.includes('#機能'));
+});
+
+// Test File Detection Logic
+tester.test('File Detection: Markdown file filtering', async () => {
+  const mockFiles = [
+    { filename: 'docs/guide.md', status: 'modified' },
+    { filename: 'docs/ja-jp/guide.md', status: 'modified' },
+    { filename: 'README.md', status: 'added' },
+    { filename: 'package.json', status: 'modified' },
+    { filename: 'docs/api.mdx', status: 'added' },
+    { filename: 'deleted.md', status: 'removed' }
+  ];
+
+  const validExtensions = ['.md', '.mdx'];
+  const filtered = mockFiles.filter(file => {
+    const hasValidExtension = validExtensions.some(ext => file.filename.endsWith(ext));
+    const isInJapaneseDir = file.filename.includes('docs/ja-jp');
+    const isAddedOrModified = ['added', 'modified'].includes(file.status);
+    
+    return hasValidExtension && !isInJapaneseDir && isAddedOrModified;
+  });
+
+  assert.strictEqual(filtered.length, 3); // guide.md, README.md, api.mdx
+  assert(filtered.some(f => f.filename === 'docs/guide.md'));
+  assert(filtered.some(f => f.filename === 'README.md'));
+  assert(filtered.some(f => f.filename === 'docs/api.mdx'));
+});
+
+// Test Japanese File Path Generation
+tester.test('Japanese Path Generation', async () => {
+  function generateJapaneseFilePath(originalPath) {
+    const pathParts = originalPath.split('/');
+    const docsIndex = pathParts.findIndex(part => part === 'docs');
+    if (docsIndex !== -1) {
+      pathParts.splice(docsIndex + 1, 0, 'ja-jp');
+    } else {
+      pathParts.unshift('docs', 'ja-jp');
+    }
+    return pathParts.join('/');
+  }
+
+  assert.strictEqual(
+    generateJapaneseFilePath('docs/guides/getting-started.md'),
+    'docs/ja-jp/guides/getting-started.md'
+  );
+  
+  assert.strictEqual(
+    generateJapaneseFilePath('README.md'),
+    'docs/ja-jp/README.md'
+  );
+});
+
+// Run all tests
+tester.run().catch(error => {
+  console.error('Test runner failed:', error);
+  process.exit(1);
+});


### PR DESCRIPTION
## 🌐 Auto-Translate Markdown to Japanese Workflow

This PR adds a comprehensive GitHub Actions workflow that automatically translates English Markdown files to Japanese using Claude Code.

### ✨ Features
- **Smart Triggering**: Only runs on merged PRs affecting `docs/en-us/**/*.md` files
- **High-Quality Translation**: Uses Claude Code for natural, technical translations
- **Metadata Preservation**: Updates front matter, adds translation banners, fixes anchor links
- **PR Automation**: Creates PRs with proper reviewers, labels, and metadata
- **Comprehensive Testing**: Unit, integration, and local test suites included

### 📁 What's Added
- **Workflow**: `.github/workflows/auto-translate-markdown-claude-reusable.yml`
- **Core Scripts**: 5 modular components in `auto-translate-markdown-claude/scripts/`
- **Test Suite**: Comprehensive tests in `auto-translate-markdown-claude/tests/`
- **Documentation**: README, design docs, and sample configurations

### 🧪 Testing Status
- ✅ All unit tests pass
- ✅ Integration tests verified  
- ✅ Local workflow testing successful
- ✅ Sample translation pipeline tested
- ✅ 17 files added, 4,935+ lines of code

### 🔧 Setup Required
Repositories using this workflow need:
- `ANTHROPIC_API_KEY` secret for Claude Code access
- `GITHUB_TOKEN` (automatically provided by GitHub)

### 📖 Usage
See `auto-translate-markdown-claude/sample-usage.md` for configuration examples.

This workflow will automatically translate documentation when PRs are merged, maintaining high quality and proper formatting throughout the translation process.