### PR TITLE
fix: Replace secrets.GITHUB_TOKEN with github.token in reusable workflow

### DIFF
--- a/.github/workflows/auto-translate-markdown-claude-reusable.yml
+++ b/.github/workflows/auto-translate-markdown-claude-reusable.yml
@@ -22,14 +22,14 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ github.token }}
 
       - name: Checkout actions repository
         uses: actions/checkout@v4
         with:
           repository: josh-wong/actions
           path: repo
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ github.token }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -56,7 +56,7 @@ jobs:
       - name: Run translation workflow
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_BODY: ${{ github.event.pull_request.body }}


### PR DESCRIPTION
## Problem

The auto-translate workflow was failing with the error:

```shell
[Invalid workflow file: .github/workflows/auto-translate-markdown-claude.yml#L18
The workflow is not valid. .github/workflows/auto-translate-markdown-claude.yml (Line: 18, Col: 21): Invalid secret, GITHUB_TOKEN is not defined in the referenced workflow.
```

**Failed workflow:** https://github.com/josh-wong/actions/actions/runs/16903404201/workflow

## Solution

This PR fixes the issue by replacing  with  in the reusable workflow.

## Changes

- **Checkout steps**: Updated both checkout actions to use  instead of 
- **Environment variables**: Updated the  environment variable to use 
- **Removed dependency**: Workflow no longer requires  to be defined as a secret input

## Why This Works

-  is automatically provided by GitHub Actions for all workflows
- It doesn't need to be defined as a secret input in the  section
- This maintains the same functionality while fixing the validation error

## Testing

- Workflow syntax is now valid
- Only requires  as a secret input
- Maintains all necessary permissions for repository operations

This fix ensures the auto-translate workflow can be properly used by other repositories without the invalid secret error.