### PR TITLE
fix: Remove GITHUB_TOKEN from calling workflow secrets

### DIFF
--- a/.github/workflows/auto-translate-markdown-claude.yml
+++ b/.github/workflows/auto-translate-markdown-claude.yml
@@ -15,6 +15,4 @@ jobs:
     uses: josh-wong/actions/.github/workflows/auto-translate-markdown-claude-reusable.yml@main
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      # Note: Do NOT use "secrets: inherit" as it will cause conflicts
-      # Only ANTHROPIC_API_KEY needs to be explicitly passed
+      # GITHUB_TOKEN is automatically available and doesn't need to be passed


### PR DESCRIPTION
## Problem

After PR #36 fixed the reusable workflow, the calling workflow still has an issue:


## Solution

This PR completes the fix by removing  from the secrets passed to the reusable workflow.

## Changes

- **Calling workflow**: Remove  from secrets in 
- **Rationale**: The reusable workflow now uses  (automatically available) instead of requiring  as a secret input

## Context

- PR #36 fixed the reusable workflow to use  instead of 
- This PR fixes the calling workflow to stop passing  as a secret
- Together, these changes resolve the validation error completely

## Testing

- Workflow syntax validation should now pass
- Only  needs to be configured as a repository secret
-  is automatically available to the reusable workflow

This completes the fix started in PR #36.