### PR TITLE
fix: Correct file paths in auto-translate workflow

### DIFF
--- a/.github/workflows/auto-translate-markdown-claude-reusable.yml
+++ b/.github/workflows/auto-translate-markdown-claude-reusable.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          cd auto-translate-markdown-claude
+          cd repo/auto-translate-markdown-claude
           npm install
 
       - name: Install Claude CLI
@@ -65,7 +65,7 @@ jobs:
           REPOSITORY_OWNER: ${{ github.repository_owner }}
           REPOSITORY_NAME: ${{ github.event.repository.name }}
         run: |
-          cd auto-translate-markdown-claude
+          cd repo/auto-translate-markdown-claude
           node scripts/translate-markdown.js
 
       - name: Comment on failure


### PR DESCRIPTION
## Problem

The auto-translate workflow failed with file path errors.

## Root Cause

The workflow has a path mismatch:
1. **Actions repository checkout**: Uses  (creates  directory)
2. **Dependency installation**: Tries to  (should be )
3. **Script execution**: Same path issue

## Solution

This PR fixes the file paths to match the checkout directory structure:

- ✅ **Fixed npm install**: 
- ✅ **Fixed script execution**: 

## Testing

After this fix:
- Dependencies should install correctly
- Script should find the translation files
- Workflow should complete successfully
- Translation files should be processed properly

This resolves the ENOENT file path errors that caused the workflow to fail.