### PR TITLE
fix: Correct working directory for translation script execution

### DIFF
--- a/.github/workflows/auto-translate-markdown-claude-reusable.yml
+++ b/.github/workflows/auto-translate-markdown-claude-reusable.yml
@@ -65,8 +65,9 @@ jobs:
           REPOSITORY_OWNER: ${{ github.repository_owner }}
           REPOSITORY_NAME: ${{ github.event.repository.name }}
         run: |
-          cd repo/auto-translate-markdown-claude
-          node scripts/translate-markdown.js
+          # Run the script from the root directory where docs/ folder exists
+          # but reference the script from the repo/ directory
+          node repo/auto-translate-markdown-claude/scripts/translate-markdown.js
 
       - name: Comment on failure
         if: failure()


### PR DESCRIPTION
## Problem

The auto-translation workflow fails with ENOENT errors because the script cannot find the docs files.

## Root Cause

Working directory mismatch:
- Calling repository (with docs folder) checked out to root directory
- Actions repository (with scripts) checked out to repo directory  
- Script execution runs from repo/auto-translate-markdown-claude directory
- Script looks for docs/en-us files from its working directory but they are in root

## Solution

Run the script from root directory where docs folder exists:

Before:
cd repo/auto-translate-markdown-claude
node scripts/translate-markdown.js

After:
node repo/auto-translate-markdown-claude/scripts/translate-markdown.js

## Changes

- Remove directory change to script folder
- Reference script with complete path from root directory
- Script can now find docs/en-us files with correct relative paths
- Resolves ENOENT file access errors

This fix ensures the translation workflow can properly access documentation files for processing.