### PR TITLE
Update auto-translate documentation workflow name and sample

### DIFF
--- a/.github/workflows/auto-translate-documentation-reusable.yml
+++ b/.github/workflows/auto-translate-documentation-reusable.yml
@@ -11,6 +11,19 @@ on:
         description: 'PR number to translate. (Optional: If not specified, the recent changes in "docs/en-us/" will be translated.)'
         required: false
         type: string
+  workflow_call:
+    inputs:
+      pr_number:
+        description: 'PR number to translate. (Optional: If not specified, the recent changes in "docs/en-us/" will be translated.)'
+        required: false
+        type: string
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN:
+        description: 'Claude Code OAuth token for authentication'
+        required: true
+      GITHUB_TOKEN:
+        description: 'GitHub token for repository access'
+        required: false
 
 permissions:
   contents: write
@@ -22,8 +35,8 @@ permissions:
 jobs:
   auto-translate:
     runs-on: ubuntu-latest
-    # Only run if PR was merged (not just closed) OR if manually triggered
-    if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
+    # Only run if PR was merged (not just closed) OR if manually triggered OR if called from another workflow
+    if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -40,8 +53,8 @@ jobs:
         uses: anthropics/claude-code-action@beta
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          trigger_phrase: ${{ github.event_name == 'workflow_dispatch' && '' || 'auto-translate' }}
-          mode: ${{ github.event_name == 'workflow_dispatch' && 'agent' || 'tag' }}
+          trigger_phrase: ${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call') && '' || 'auto-translate' }}
+          mode: ${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call') && 'agent' || 'tag' }}
           direct_prompt: |
             A documentation PR has been merged. Please translate any English documentation changes to Japanese and create a new PR.
 

--- a/auto-translate-markdown-script/README.md
+++ b/auto-translate-markdown-script/README.md
@@ -26,7 +26,7 @@ The workflow is built by using GitHub Actions and Claude Code Action to provide 
 
 ### 📄 Auto-translate documentation workflow file
 
-The complete workflow configuration is available in [`.github/workflows/auto-translate-documentation.yml`](/.github/workflows/auto-translate-documentation.yml).
+The complete workflow configuration is available in [`.github/workflows/auto-translate-documentation-reusable.yml`](/.github/workflows/auto-translate-documentation-reusable.yml).
 
 This workflow file contains:
 
@@ -127,7 +127,7 @@ You can customize the workflow behavior to match your specific requirements.
 
 ### 🔧 Modify translation behavior
 
-If necessary, you can edit `direct_prompt` in `auto-translate-documentation.yml` to change translation behavior:
+If necessary, you can edit `direct_prompt` in `auto-translate-documentation-reusable.yml` to change translation behavior:
 
 ```yaml
 direct_prompt: |

--- a/auto-translate-markdown-script/sample-usage.yaml
+++ b/auto-translate-markdown-script/sample-usage.yaml
@@ -1,112 +1,26 @@
-# Sample usage for Auto-Translate Documentation with Claude Code Action
-# This shows how to set up automated Japanese translation of English documentation
+# Sample usage for auto-translate documentation by using Claude Code Action
+# The following approach is a reusable workflow that calls the centralized workflow file (.github/workflows/auto-translate-docs-reusable.yml) in the josh-wong/actions from any repository.
+# NOTE: Name this file ".github/workflows/auto-translate-docs-reusable.yml"
 
-# AUTOMATIC TRANSLATION: Runs when documentation PRs are merged
-# File: .github/workflows/auto-translate-documentation.yml
-name: Auto-Translate Documentation
+name: Auto-translate documentation (ja-jp)
 on:
   pull_request:
-    types: [closed]  # Only trigger when PR is merged
+    types: [closed]
     paths:
       - "docs/en-us/**/*.mdx"
       - "docs/en-us/**/*.md"
-
-permissions:
-  contents: write
-  pull-requests: write
-  issues: write
-  id-token: write
-
-jobs:
-  auto-translate:
-    runs-on: ubuntu-latest
-    if: github.event.pull_request.merged == true
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Auto-translate documentation to Japanese
-        uses: anthropics/claude-code-action@beta
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}  # Required: Set this in repository secrets
-          direct_prompt: |
-            A documentation PR has been merged. Please translate any English documentation changes to Japanese.
-
-            ## Task:
-            1. Identify files that were changed in the merged PR in the docs/en-us/ directory
-            2. For each changed file, create or update the corresponding Japanese translation in docs/ja-jp/
-            3. Maintain the same directory structure and filename in the Japanese docs
-
-            ## Requirements:
-            - Translate all English text to natural, professional Japanese
-            - Preserve all MDX/Markdown formatting exactly (headers, lists, code blocks, links)
-            - Keep code examples, URLs, and technical terms in English
-            - Ensure proper UTF-8 encoding for Japanese characters
-            - Create docs/ja-jp/ directory structure if it doesn't exist
-
-            ## Process:
-            1. Use git to identify which files were modified in the merged PR
-            2. Read each modified English documentation file
-            3. Create high-quality Japanese translations
-            4. Save translations in docs/ja-jp/ with identical file structure
-            5. Commit the translations with a descriptive message
-
-            Please analyze the merged PR and create the necessary Japanese translations.
-
-          allowed_tools: "View,Edit,Glob,Grep,Bash(git:*),Bash(mkdir:*)"
-          timeout_minutes: 20
-
----
-
-# MANUAL TRANSLATION: Triggered by @claude comments
-# File: .github/workflows/claude-translation-assistant.yml  
-name: Claude Manual Translation Assistant
-on:
-  issue_comment:
-    types: [created]
-  pull_request_review_comment:
-    types: [created]
-
-permissions:
-  contents: write
-  pull-requests: write
-  issues: write
-  id-token: write
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to translate (optional)'
+        required: false
+        type: string
 
 jobs:
-  claude-assistant:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: anthropics/claude-code-action@beta
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}  # Required: Set this in repository secrets
-          trigger_phrase: "@claude"
-          custom_instructions: |
-            You are a documentation translation specialist for manual translation requests.
-
-            When users ask you to translate documentation (for example, "@claude translate docs"):
-            
-            1. **Find Documentation**: Look for English files in docs/en-us/ directory
-            2. **Create Translations**: Generate Japanese versions in docs/ja-jp/ with same structure
-            3. **Preserve Formatting**: Keep all MDX/Markdown formatting, code blocks, and links exactly
-            4. **Professional Japanese**: Use natural, technical Japanese for text content
-            5. **Commit Changes**: Save translations with descriptive commit messages
-
-            This is for manual, on-demand translation requests only.
-          
-          allowed_tools: "View,Edit,Glob,Grep,Bash(git:*),Bash(mkdir:*)"
-          timeout_minutes: 15
-
-# SETUP REQUIREMENTS:
-# 1. Add CLAUDE_CODE_OAUTH_TOKEN to repository secrets (Settings > Secrets and variables > Actions)
-#    Generate token by running: claude setup-token (for Pro/Max users)
-# 2. Ensure repository has proper permissions for the workflows
-# 3. Create docs/en-us/ directory structure for English documentation
-# 4. Japanese translations will be automatically created in docs/ja-jp/
-
-# USAGE:
-# Automatic: Merge any PR with changes to docs/en-us/ files
-# Manual: Comment "@claude translate docs" on any PR or issue
+  translate-docs:
+    uses: josh-wong/actions/.github/workflows/auto-translate-documentation-reusable.yml@main
+    with:
+      pr_number: ${{ inputs.pr_number || '' }}
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

This PR refactors and improves the workflow for automatically translating English documentation to Japanese using Claude Code Action. The main changes include converting the workflow to a reusable format, updating the trigger logic to support workflow calls, and simplifying the sample usage to demonstrate how to use the new reusable workflow.

## Related issues and/or PRs

N/A

## Changes made

* **Workflow refactoring and reusability:**
  * Renamed `.github/workflows/auto-translate-documentation.yml` to `.github/workflows/auto-translate-documentation-reusable.yml` and added support for `workflow_call`, allowing the workflow to be invoked from other workflows or repositories.
  * Updated the job trigger condition to run on merged PRs, manual dispatch, or when called from another workflow, increasing flexibility.
* **Simplification and documentation:**
  * Replaced the previous sample workflow in `auto-translate-markdown-script/sample-usage.yaml` with a streamlined example that demonstrates how to call the reusable workflow, removing manual job definitions and legacy instructions.
* **Configuration improvements:**
  * Updated the action input parameters to properly handle both manual and workflow call triggers, ensuring correct behavior for `trigger_phrase` and `mode`.

<h2 id="checklist">Checklist</h2>

If any items in this checklist aren't applicable to this PR, add `N/A` after the item and check the checkbox.

### Documentation

- [x] I have updated the documentation to reflect the changes.
- [x] I have documented or updated any remaining open issues linked to this PR in GitHub, Obsidian, etc.

### Build, deploy, and test

- [x] I have merged and published any dependent changes in other PRs.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have thoroughly tested my changes and confirmed functionality.
- [x] My changes generate no new warnings.