### PR TITLE
Fix: Remove GITHUB_TOKEN from workflow_call secrets

### DIFF
--- a/.github/workflows/auto-translate-documentation-reusable.yml
+++ b/.github/workflows/auto-translate-documentation-reusable.yml
@@ -21,9 +21,6 @@ on:
       CLAUDE_CODE_OAUTH_TOKEN:
         description: 'Claude Code OAuth token for authentication'
         required: true
-      GITHUB_TOKEN:
-        description: 'GitHub token for repository access'
-        required: false
 
 permissions:
   contents: write

--- a/auto-translate-markdown-script/sample-usage.yaml
+++ b/auto-translate-markdown-script/sample-usage.yaml
@@ -23,4 +23,3 @@ jobs:
       pr_number: ${{ inputs.pr_number || '' }}
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

This PR fixes the collision error that occurs when calling the reusable workflow from private repositories.

## Problem
When trying to call the auto-translate workflow from another private repository, users encounter this error:


## Solution
- Removed `GITHUB_TOKEN` from the `secrets` section in the `workflow_call` event of the reusable workflow
- Updated the sample usage file to not explicitly pass `GITHUB_TOKEN`
- `GITHUB_TOKEN` is automatically available in all GitHub Actions workflows and doesn't need to be explicitly passed

## Changes Made
- **`.github/workflows/auto-translate-documentation-reusable.yml`**: Removed `GITHUB_TOKEN` from workflow_call secrets
- **`auto-translate-markdown-script/sample-usage.yaml`**: Removed `GITHUB_TOKEN` from secrets section

## Testing
- [x] Workflow syntax is valid
- [x] No reserved name collisions
- [x] `GITHUB_TOKEN` is still accessible within the workflow steps

## Related Issues
Fixes the workflow call error reported by users when implementing the auto-translate functionality in private repositories.