### PR TITLE
Add steps for obtaining and adding Claude Code OAuth token to auto-translation workflow README

### DIFF
--- a/auto-translate-markdown-script/README.md
+++ b/auto-translate-markdown-script/README.md
@@ -10,8 +10,11 @@ This section covers the essential setup steps to get the auto-translation workfl
 
 Add your Claude Code OAuth token to repository secrets:
 
-1. Go to **Settings** → **Secrets and variables** → **Actions**.
-2. Create a new repository secret: `CLAUDE_CODE_OAUTH_TOKEN` = your Claude Code OAuth token
+1. **Install Claude Code:** Ensure that you have Claude Code installed on your computer.
+2. **Generate an OAuth token:** In **Terminal** on your computer, run `claude setup-token` and follow the instructions to get a Claude Code OAuth token.
+3. **Add the token to the repository secrets:**
+   - Go to **Settings** → **Secrets and variables** → **Actions**.
+   - Create a new repository secret: `CLAUDE_CODE_OAUTH_TOKEN` = your Claude Code OAuth token
 
 ### ✅ Ready to use
 


### PR DESCRIPTION
## Description

This PR updates the setup instructions for configuring the auto-translation workflow in the `auto-translate-markdown-script/README.md`. The main change is a more detailed and user-friendly guide for obtaining and adding the Claude Code OAuth token.

## Related issues and/or PRs

N/A

## Changes made

* Added explicit instructions to install Claude Code locally and generate an OAuth token using the `claude setup-token` command, making the setup process clearer for new users.
* Clarified the steps for adding the token to repository secrets by breaking them into sub-steps for easier understanding.

<h2 id="checklist">Checklist</h2>

If any items in this checklist aren't applicable to this PR, add `N/A` after the item and check the checkbox.

### Documentation

- [x] I have updated the documentation to reflect the changes.
- [x] I have documented or updated any remaining open issues linked to this PR in GitHub, Obsidian, etc.

### Build, deploy, and test

- [x] I have merged and published any dependent changes in other PRs.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have thoroughly tested my changes and confirmed functionality.
- [x] My changes generate no new warnings.
