### PR TITLE
docs: Add OAuth token expiration notice

### DIFF
--- a/auto-translate-markdown-script/README.md
+++ b/auto-translate-markdown-script/README.md
@@ -16,6 +16,10 @@ Add your Claude Code OAuth token to repository secrets:
    - Go to **Settings** → **Secrets and variables** → **Actions**.
    - Create a new repository secret: `CLAUDE_CODE_OAUTH_TOKEN` = your Claude Code OAuth token
 
+> [!IMPORTANT]
+>
+> **Regarding token expiration:** The Claude Code OAuth token is valid for only one year and must be renewed after expiration. Make a note to renew your token before it expires to avoid workflow disruptions.
+
 ### ✅ Ready to use
 
 After authentication is configured, the workflow is ready to use in two ways:


### PR DESCRIPTION
## Description

This PR adds an important notice about the Claude Code OAuth token expiration to help users avoid workflow disruptions.

## Changes Made

- **Added expiration notice**: Informs users that the Claude Code OAuth token is valid for only one year
- **Renewal reminder**: Advises users to make a note about renewing the token before expiration
- **Improved visibility**: Uses GitHub-flavored markdown "Important" admonition for better visibility

## Problem Addressed

Users were not aware that the Claude Code OAuth token expires after one year, which could lead to:
- Unexpected workflow failures
- Translation automation disruptions
- Need for emergency token renewal

## Solution

Added a prominent notice in the authentication setup section that clearly states:
- Token validity period (one year)
- Renewal requirement
- Proactive planning advice

## Benefits

- **Prevents workflow disruptions**: Users can plan for token renewal
- **Improves user experience**: Clear communication about token lifecycle
- **Reduces support requests**: Proactive information reduces confusion

This ensures users are properly informed about token maintenance requirements.