### PR TITLE
Add workflow for detecting missing projects in PRs

### DIFF
--- a/.github/workflows/auto-pr-reusable.yaml
+++ b/.github/workflows/auto-pr-reusable.yaml
@@ -9,7 +9,7 @@ on:
         description: 'The base name of the projects used in the repository. For example, "Project" if projects are named "Project <version>".'
 
 env:
-  TERM: dumb
+  TERM: xterm
 jobs:
   create_backport_pull_requests:
     if: github.event.pull_request.merged == true

--- a/.github/workflows/pr-project-assignment-check-reusable.yml
+++ b/.github/workflows/pr-project-assignment-check-reusable.yml
@@ -19,7 +19,7 @@ on:
         required: false
         type: string
         description: 'Custom warning message when no project is assigned'
-        default: 'No project assigned to this PR. Consider assigning a project if this change should be tracked for a specific release.'
+        default: 'No project assigned to this PR. Consider assigning projects if this change should be applied to other versions/releases.'
 
 env:
   TERM: xterm
@@ -44,12 +44,12 @@ jobs:
           SCRIPT_PATH: ./pr-project-assignment-script
         run: |
           echo "Checking project assignment for PR #${{ inputs.pr_number }}..."
-          
-          # Get projects assigned to the PR
+
+          # Get projects assigned to the PR.
           projects=$($SCRIPT_PATH/check_pr_project_assignment "${{ inputs.repo_owner }}" "${{ inputs.repo_name }}" "${{ inputs.pr_number }}")
-          
+
           if [[ -z "$projects" ]]; then
-            echo "::warning title=No Project Assigned::${{ inputs.warning_message }}"
+            echo "::warning title=No projects assigned::${{ inputs.warning_message }}"
             echo "ℹ️ This is a warning only and will not block the PR."
           else
             echo "✅ PR is assigned to projects: $projects"

--- a/.github/workflows/pr-project-assignment-check-reusable.yml
+++ b/.github/workflows/pr-project-assignment-check-reusable.yml
@@ -1,0 +1,56 @@
+name: PR Project Assignment Check
+
+on:
+  workflow_call:
+    inputs:
+      pr_number:
+        required: true
+        type: number
+        description: 'Pull request number to check for project assignment'
+      repo_owner:
+        required: true
+        type: string
+        description: 'Repository owner'
+      repo_name:
+        required: true
+        type: string
+        description: 'Repository name'
+      warning_message:
+        required: false
+        type: string
+        description: 'Custom warning message when no project is assigned'
+        default: 'No project assigned to this PR. Consider assigning a project if this change should be tracked for a specific release.'
+
+env:
+  TERM: xterm
+
+jobs:
+  check_project_assignment:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Checkout pr-project-assignment scripts
+        uses: actions/checkout@v6
+        with:
+          repository: scalar-labs/actions
+          sparse-checkout: pr-project-assignment-script
+          ref: main
+          path: pr-project-assignment
+
+      - name: Check for project assignment
+        working-directory: pr-project-assignment
+        env:
+          SCRIPT_PATH: ./pr-project-assignment-script
+        run: |
+          echo "Checking project assignment for PR #${{ inputs.pr_number }}..."
+          
+          # Get projects assigned to the PR
+          projects=$($SCRIPT_PATH/check_pr_project_assignment "${{ inputs.repo_owner }}" "${{ inputs.repo_name }}" "${{ inputs.pr_number }}")
+          
+          if [[ -z "$projects" ]]; then
+            echo "::warning title=No Project Assigned::${{ inputs.warning_message }}"
+            echo "ℹ️ This is a warning only and will not block the PR."
+          else
+            echo "✅ PR is assigned to projects: $projects"
+          fi

--- a/pr-project-assignment-script/README.md
+++ b/pr-project-assignment-script/README.md
@@ -1,0 +1,20 @@
+# Set up workflow for checking PR project assignments
+
+The [`.github/workflows/pr-project-assignment-check-reusable.yml`](../.github/workflows/pr-project-assignment-check-reusable.yml) workflow checks if a PR has a project assigned in the GitHub sidebar. The following outcomes are possible when the workflow runs:
+
+- **If projects are assigned:** Returns a comma-separated list of project titles.
+- **If no projects are assigned:** Returns an empty output.
+  - The workflow shows a warning annotation (non-blocking) if no projects are found. The reason why this is a warning and not an error is to allow flexibility in cases where project assignment may not be mandatory.
+
+## Requirements
+
+- The repository must have GitHub Projects enabled.
+- The workflow requires `contents: read` permission.
+
+## Implement the workflow
+
+Copy the [`pr-project-assignment-check.yaml`](./pr-project-assignment-check.yaml) file to your repository's `.github/workflows/` directory to automatically check project assignments when PRs are opened.
+
+> [!NOTE]
+>
+> The [`check_pr_project_assignment`](./check_pr_project_assignment) script queries GitHub's GraphQL API to check for project assignments. You don't need to include it in your repository, unless you want to customize the script for your specific needs.

--- a/pr-project-assignment-script/check_pr_project_assignment
+++ b/pr-project-assignment-script/check_pr_project_assignment
@@ -11,7 +11,7 @@ repo_owner=$1
 repo_name=$2
 pull_request_id=$3
 
-# Get GitHub projects associated with the PR
+# Get GitHub projects associated with the PR.
 projects_json=$(gh api graphql -F owner=$repo_owner -F repoName=$repo_name -F pullRequestId=$pull_request_id -f query='
   query($owner: String!, $repoName: String!, $pullRequestId: Int!) {
     repository(owner: $owner, name: $repoName) {
@@ -26,5 +26,5 @@ projects_json=$(gh api graphql -F owner=$repo_owner -F repoName=$repo_name -F pu
   }
 ')
 
-# Extract project titles and return them as a comma-separated list
+# Extract project titles and return them as a comma-separated list. If no projects are assigned, this will return an empty string.
 echo $projects_json | jq -r '.data.repository.pullRequest.projectsV2.nodes[].title' | tr '\n' ',' | sed 's/,$//'

--- a/pr-project-assignment-script/check_pr_project_assignment
+++ b/pr-project-assignment-script/check_pr_project_assignment
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -e -o pipefail; [[ -n "$DEBUG" ]] && set -x
+
+if [[ $# -ne 3 ]]; then
+    echo "usage: $0 repo_owner repo_name pull_request_id"
+    exit 1
+fi
+
+repo_owner=$1
+repo_name=$2
+pull_request_id=$3
+
+# Get GitHub projects associated with the PR
+projects_json=$(gh api graphql -F owner=$repo_owner -F repoName=$repo_name -F pullRequestId=$pull_request_id -f query='
+  query($owner: String!, $repoName: String!, $pullRequestId: Int!) {
+    repository(owner: $owner, name: $repoName) {
+      pullRequest(number: $pullRequestId) {
+        projectsV2(first: 100) {
+          nodes {
+            title
+          }
+        }
+      }
+    }
+  }
+')
+
+# Extract project titles and return them as a comma-separated list
+echo $projects_json | jq -r '.data.repository.pullRequest.projectsV2.nodes[].title' | tr '\n' ',' | sed 's/,$//'

--- a/pr-project-assignment-script/pr-project-assignment-check.yaml
+++ b/pr-project-assignment-script/pr-project-assignment-check.yaml
@@ -1,0 +1,23 @@
+name: PR Project Assignment Check
+
+# This workflow checks if the pull request has a project assigned
+# and shows a warning (non-blocking) if no project is found
+# 
+# To use this workflow in your repository:
+# 1. Create a .github/workflows directory if it doesn't exist
+# 2. Copy this file to .github/workflows/pr-project-assignment-check.yml
+# 3. Customize the warning message if needed
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  check_project_assignment:
+    uses: scalar-labs/actions/.github/workflows/pr-project-assignment-check-reusable.yml@main
+    with:
+      pr_number: ${{ github.event.pull_request.number }}
+      repo_owner: ${{ github.repository_owner }}
+      repo_name: ${{ github.event.repository.name }}
+      # Optional: customize the warning message
+      warning_message: 'No project assigned to this PR. Consider assigning a project if this change should be tracked for a specific release.'


### PR DESCRIPTION
## Description

This PR introduces a reusable GitHub Actions workflow and supporting scripts to automatically check whether a pull request has an assigned GitHub Project, and to provide a non-blocking warning if not. The implementation includes a shell script for querying project assignments, workflow configuration files, and documentation to help teams adopt this check in their repositories.

## Related issues and/or PRs

N/A

## Changes made

**Workflow for checking project assignment**

* Added `.github/workflows/pr-project-assignment-check-reusable.yml`, a reusable workflow that checks if a PR is assigned to any GitHub Projects and emits a warning if not. It uses inputs for PR number, repo owner, name, and a customizable warning message.
* Added `pr-project-assignment-script/pr-project-assignment-check.yaml`, an example workflow consumers can copy into their own repositories to enable the project assignment check on PR open.
* Added `pr-project-assignment-script/check_pr_project_assignment`, a Bash script that uses GitHub's GraphQL API to fetch project assignments for a given PR and outputs a comma-separated list of project titles (empty if none).

**Documentation**

* Added `pr-project-assignment-script/README.md` with setup instructions, requirements, and usage notes for the project assignment check workflow and script.

**Other changes**

* Changed the `TERM` environment variable from `dumb` to `xterm` in `.github/workflows/auto-pr-reusable.yaml` since "dumb" is not a word that should be used.

<h2 id="checklist">Checklist</h2>

If any items in this checklist aren't applicable to this PR, add `N/A` after the item and check the checkbox.

### Documentation

- [x] I have updated the documentation to reflect the changes.
- [x] I have documented or updated any remaining open issues linked to this PR in GitHub, Obsidian, etc.

### Build, deploy, and test

- [x] I have merged and published any dependent changes in other PRs.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have thoroughly tested my changes and confirmed functionality.
- [x] My changes generate no new warnings.
