### PR TITLE
Add comment function to workflow for checking project assignments

### DIFF
--- a/.github/workflows/pr-project-assignment-check-reusable.yml
+++ b/.github/workflows/pr-project-assignment-check-reusable.yml
@@ -21,6 +21,10 @@ on:
         description: 'Custom warning message when no project is assigned'
         default: 'No project assigned to this PR. Consider assigning projects if this change should be applied to other versions/releases.'
 
+permissions:
+  contents: read
+  pull-requests: write
+
 env:
   TERM: xterm
 
@@ -51,6 +55,35 @@ jobs:
           if [[ -z "$projects" ]]; then
             echo "::warning title=No projects assigned::${{ inputs.warning_message }}"
             echo "ℹ️ This is a warning only and will not block the PR."
+            echo "no_projects=true" >> $GITHUB_OUTPUT
           else
             echo "✅ PR is assigned to projects: $projects"
+            echo "no_projects=false" >> $GITHUB_OUTPUT
           fi
+        id: check_projects
+
+      - name: Comment on PR when no projects are assigned
+        if: steps.check_projects.outputs.no_projects == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: pr } = await github.rest.pulls.get({
+              owner: '${{ inputs.repo_owner }}',
+              repo: '${{ inputs.repo_name }}',
+              pull_number: ${{ inputs.pr_number }}
+            });
+
+            const comment = `⚠️ @${pr.user.login} ${{ inputs.warning_message }}
+
+            **Please choose one:**
+            - **If this change affects specific versions/releases:** Assign this PR to the appropriate project versions in the sidebar.
+            - **If no project tracking is needed:** React with 👍 on this comment.
+
+            This helps ensure proper change tracking across releases and versions.`;
+
+            await github.rest.issues.createComment({
+              owner: '${{ inputs.repo_owner }}',
+              repo: '${{ inputs.repo_name }}',
+              issue_number: ${{ inputs.pr_number }},
+              body: comment
+            });

--- a/pr-project-assignment-script/README.md
+++ b/pr-project-assignment-script/README.md
@@ -3,13 +3,14 @@
 The [`.github/workflows/pr-project-assignment-check-reusable.yml`](../.github/workflows/pr-project-assignment-check-reusable.yml) workflow checks if a PR has a project assigned in the GitHub sidebar. The following outcomes are possible when the workflow runs:
 
 - **If projects are assigned:** Returns a comma-separated list of project titles.
+  - A comment will be posted on the PR, mentioning the PR creator (@username) as a heads-up.
 - **If no projects are assigned:** Returns an empty output.
   - The workflow shows a warning annotation (non-blocking) if no projects are found. The reason why this is a warning and not an error is to allow flexibility in cases where project assignment may not be mandatory.
 
 ## Requirements
 
 - The repository must have GitHub Projects enabled.
-- The workflow requires `contents: read` permission.
+- The workflow requires `contents: read` and `pull-requests: write` permissions.
 
 ## Implement the workflow
 

--- a/pr-project-assignment-script/pr-project-assignment-check.yaml
+++ b/pr-project-assignment-script/pr-project-assignment-check.yaml
@@ -11,6 +11,10 @@ on:
   pull_request:
     types: [opened]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   check_project_assignment:
     uses: josh-wong/actions/.github/workflows/pr-project-assignment-check-reusable.yml@main


### PR DESCRIPTION
## Description

This PR enhances the GitHub Actions workflow for checking PR project assignments by automatically commenting on PRs that lack project assignments, guiding contributors on next steps, and clarifying required permissions in both workflow files and documentation.

## Related issues and/or PRs

- #99 

## Changes made

**Workflow automation improvements**

* Added a step to automatically comment on PRs without assigned projects, mentioning the PR creator and providing clear instructions for project assignment or acknowledgment.
* The script now outputs whether projects are assigned, enabling conditional steps in the workflow.

**Permissions updates**

* Updated workflow files (`.github/workflows/pr-project-assignment-check-reusable.yml` and `pr-project-assignment-script/pr-project-assignment-check.yaml`) to explicitly request `contents: read` and `pull-requests: write` permissions, which are required for posting comments. [[1]](diffhunk://#diff-3f3a4d563de3654c0c12306f66a5de2af735b1daba44b3b35983463547e2aa43R24-R27) [[2]](diffhunk://#diff-737a7d5f0692fe1ea77ddd9748cc81b9c6fdbbbf7aee107f747474ff3e6127b2R14-R17)
* Updated documentation in `pr-project-assignment-script/README.md` to reflect the new permissions and behavior.

<h2 id="checklist">Checklist</h2>

If any items in this checklist aren't applicable to this PR, add `N/A` after the item and check the checkbox.

### Documentation

- [x] I have updated the documentation to reflect the changes.
- [x] I have documented or updated any remaining open issues linked to this PR in GitHub, Obsidian, etc.

### Build, deploy, and test

- [x] I have merged and published any dependent changes in other PRs.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have thoroughly tested my changes and confirmed functionality.
- [x] My changes generate no new warnings.
