### PR TITLE
Add missing `projects` requirement to workflow for checking project assignments

### DIFF
--- a/.github/workflows/pr-project-assignment-check-reusable.yml
+++ b/.github/workflows/pr-project-assignment-check-reusable.yml
@@ -24,6 +24,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  projects: read
 
 env:
   TERM: xterm

--- a/pr-project-assignment-script/README.md
+++ b/pr-project-assignment-script/README.md
@@ -10,7 +10,7 @@ The [`.github/workflows/pr-project-assignment-check-reusable.yml`](../.github/wo
 ## Requirements
 
 - The repository must have GitHub Projects enabled.
-- The workflow requires `contents: read` and `pull-requests: write` permissions.
+- The workflow requires `contents: read`, `pull-requests: write`, and `projects: read` permissions.
 
 ## Implement the workflow
 

--- a/pr-project-assignment-script/pr-project-assignment-check.yaml
+++ b/pr-project-assignment-script/pr-project-assignment-check.yaml
@@ -14,6 +14,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  projects: read
 
 jobs:
   check_project_assignment:


### PR DESCRIPTION
## Description

This PR updates the permissions required for the pull request project assignment check workflow to include read access to GitHub Projects. This ensures that the workflow can properly interact with project-related data. The documentation is also updated to reflect this new requirement.

## Related issues and/or PRs

- #99 
- #100 

## Changes made

**Workflow permission updates**

* Added `projects: read` permission to `.github/workflows/pr-project-assignment-check-reusable.yml` to enable the workflow to read project information.
* Added `projects: read` permission to `pr-project-assignment-script/pr-project-assignment-check.yaml` for the same purpose.

**Documentation update**

* Updated `pr-project-assignment-script/README.md` to document the new required `projects: read` permission for the workflow.

<h2 id="checklist">Checklist</h2>

If any items in this checklist aren't applicable to this PR, add `N/A` after the item and check the checkbox.

### Documentation

- [x] I have updated the documentation to reflect the changes.
- [x] I have documented or updated any remaining open issues linked to this PR in GitHub, Obsidian, etc.

### Build, deploy, and test

- [x] I have merged and published any dependent changes in other PRs.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have thoroughly tested my changes and confirmed functionality.
- [x] My changes generate no new warnings.
