### PR TITLE
Add support for private projects in workflow for checking project assignments in PRs

### DIFF
--- a/.github/workflows/pr-project-assignment-check-reusable.yml
+++ b/.github/workflows/pr-project-assignment-check-reusable.yml
@@ -20,6 +20,10 @@ on:
         type: string
         description: 'Custom warning message when no projects are assigned'
         default: 'No projects are assigned to this PR. Consider assigning projects if this change should be applied to other version/release branches.'
+    secrets:
+      PROJECT_TOKEN:
+        required: false
+        description: 'Personal Access Token with read:project scope for private project detection'
 
 permissions:
   contents: read
@@ -32,7 +36,8 @@ jobs:
   check_project_assignment:
     runs-on: ubuntu-latest
     env:
-      GH_TOKEN: ${{ github.token }}
+      # Use PROJECT_TOKEN if provided (for private projects), otherwise use GITHUB_TOKEN
+      GH_TOKEN: ${{ secrets.PROJECT_TOKEN || github.token }}
     steps:
       - name: Checkout pr-project-assignment scripts
         uses: actions/checkout@v6

--- a/pr-project-assignment-script/README.md
+++ b/pr-project-assignment-script/README.md
@@ -16,9 +16,20 @@ The [`.github/workflows/pr-project-assignment-check-reusable.yml`](../.github/wo
 >
 > Supports all GitHub project types:
 >
-> - Organization and repository-level GitHub Projects V2
-> - User-level GitHub Projects V2
-> - Classic project boards (legacy)
+> - Organization and repository-level GitHub Projects V2 (public projects work with default token)
+> - User-level GitHub Projects V2 (requires optional token for private projects)  
+> - Classic project boards (legacy, being deprecated)
+
+### Optional: Private project support
+
+To detect **private projects**, you'll need to provide a Personal Access Token with `read:project` scope:
+
+1. **Create a PAT:** Go to [GitHub Settings > Developer settings > Personal access tokens](https://github.com/settings/tokens)
+2. **Add `read:project` scope:** This enables access to private projects.
+3. **Add as repository secret:** Store the token as `PROJECT_READ_TOKEN` in your repository secrets.
+4. **Uncomment the secrets section** in your workflow file (see example in sample workflow).
+
+**Without this optional token:** Only public projects will be detected. Private projects will be ignored, and the workflow will only return public projects assigned to the PR.
 
 ## Implement the workflow
 

--- a/pr-project-assignment-script/pr-project-assignment-check.yaml
+++ b/pr-project-assignment-script/pr-project-assignment-check.yaml
@@ -24,3 +24,6 @@ jobs:
       repo_name: ${{ github.event.repository.name }}
       # Optional: Customize the warning message.
       warning_message: 'No projects are assigned to this PR. Consider assigning projects if this change should be applied to other version/release branches.'
+    secrets:
+      # Provide a PAT with 'read:project' scope to detect private projects.
+      # PROJECT_TOKEN: ${{ secrets.PROJECT_READ_TOKEN }}


### PR DESCRIPTION
## Description

This PR adds support for detecting private GitHub Projects in the PR project assignment workflow. It introduces an optional secret for a Personal Access Token (PAT) with the necessary scope, updates documentation to explain how to use it, and adjusts the workflow to use this token when available.

## Related issues and/or PRs

- #99
- #100 
- #101 

## Changes made

**Private project detection support**

* Added an optional `PROJECT_TOKEN` secret input to `.github/workflows/pr-project-assignment-check-reusable.yml` to allow using a PAT with `read:project` scope for private project detection.
* Updated the workflow environment to use `PROJECT_TOKEN` if provided, otherwise defaulting to `GITHUB_TOKEN`, ensuring private projects can be detected when the PAT is supplied.
* Documented the use of the `PROJECT_TOKEN` secret in the sample workflow in `pr-project-assignment-script/pr-project-assignment-check.yaml`, including commented guidance for providing the PAT.

**Documentation updates**

* Expanded the `pr-project-assignment-script/README.md` to explain the need for a PAT with `read:project` scope for private project detection, with step-by-step instructions for setup and clarifications on public vs. private project detection.

<h2 id="checklist">Checklist</h2>

If any items in this checklist aren't applicable to this PR, add `N/A` after the item and check the checkbox.

### Documentation

- [x] I have updated the documentation to reflect the changes.
- [x] I have documented or updated any remaining open issues linked to this PR in GitHub, Obsidian, etc.

### Build, deploy, and test

- [x] I have merged and published any dependent changes in other PRs.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have thoroughly tested my changes and confirmed functionality.
- [x] My changes generate no new warnings.
