### PR TITLE
Add bump-doc-versions script and reusable workflow

### DIFF
--- a/.github/workflows/bump-doc-versions-reusable.yaml
+++ b/.github/workflows/bump-doc-versions-reusable.yaml
@@ -1,0 +1,215 @@
+name: Bump doc versions (reusable)
+
+# Reusable workflow: runs `bump-doc-versions` against the calling repository and
+# opens (or updates) a PR with the anchored patch-version rewrites. Called by
+# the internal-repo dispatch caller and the public-repo safety-net caller.
+# See the version-bump-automation design doc §6.2 for the specification.
+
+on:
+  workflow_call:
+    inputs:
+      product:
+        description: 'scalardb | scalardl'
+        required: true
+        type: string
+      repo:
+        description: 'internal | public — selects the file-scope map'
+        required: true
+        type: string
+      minor:
+        description: 'Minor version key: "3.17" or "current"'
+        required: true
+        type: string
+      to:
+        description: 'Target full version X.Y.Z'
+        required: true
+        type: string
+      from:
+        description: 'Source version X.Y.Z. Optional — auto-derived from className (public) or the first anchored match (internal) when omitted.'
+        required: false
+        type: string
+        default: ''
+      base_branch:
+        description: 'Branch to open the PR against (e.g., "3.17" for internal, "main" for public)'
+        required: true
+        type: string
+      head_branch:
+        description: 'Branch that carries the bump commit (e.g., "update-3.17-patch-version-to-3.17.4")'
+        required: true
+        type: string
+      pr_title:
+        description: 'Title of the opened PR'
+        required: true
+        type: string
+      pr_body_style:
+        description: 'internal | public-safety-net — chooses the PR body template'
+        required: false
+        type: string
+        default: 'internal'
+      dry_run:
+        description: 'If true, run the script but do not commit / push / open a PR'
+        required: false
+        type: boolean
+        default: false
+    secrets:
+      github_token:
+        description: 'Token with `contents: write` and `pull-requests: write` on the caller repo. GITHUB_TOKEN works for same-repo operations.'
+        required: true
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      # Derive the actions repo + ref from `github.workflow_ref` so this same
+      # workflow works whether the caller pins `@main`, `@v1`, or a SHA.
+      - name: Resolve actions repo & ref
+        id: refs
+        env:
+          WFREF: ${{ github.workflow_ref }}
+        run: |
+          # WFREF looks like: owner/repo/.github/workflows/name.yaml@refs/heads/main
+          repo="${WFREF%%/.github/*}"
+          ref="${WFREF##*@}"
+          echo "repo=$repo" >> "$GITHUB_OUTPUT"
+          echo "ref=$ref"   >> "$GITHUB_OUTPUT"
+          echo "Using script source: $repo @ $ref"
+
+      - name: Checkout bump-doc-versions script
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ steps.refs.outputs.repo }}
+          ref: ${{ steps.refs.outputs.ref }}
+          sparse-checkout: bump-doc-versions
+          path: actions-tools
+
+      - name: Checkout target repo at base_branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.base_branch }}
+          fetch-depth: 0
+          token: ${{ secrets.github_token }}
+          path: repo
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Run bump-doc-versions
+        id: bump
+        working-directory: repo
+        env:
+          PRODUCT:   ${{ inputs.product }}
+          REPO_KIND: ${{ inputs.repo }}
+          MINOR:     ${{ inputs.minor }}
+          TO:        ${{ inputs.to }}
+          FROM:      ${{ inputs.from }}
+          DRY_RUN:   ${{ inputs.dry_run }}
+        run: |
+          # Build the command as an array so no user-controlled string is
+          # interpolated into a shell string.
+          cmd=(node ../actions-tools/bump-doc-versions/bump-doc-versions.mjs
+            --product "$PRODUCT"
+            --repo    "$REPO_KIND"
+            --minor   "$MINOR"
+            --to      "$TO"
+            --json-report /tmp/bump-report.json)
+          if [ -n "$FROM" ]; then cmd+=(--from "$FROM"); fi
+          if [ "$DRY_RUN" = "true" ]; then cmd+=(--dry-run); fi
+
+          set +e
+          "${cmd[@]}"
+          ec=$?
+          set -e
+          echo "exit_code=$ec" >> "$GITHUB_OUTPUT"
+          # We do not fail here; downstream steps interpret the exit code.
+
+      - name: No-op (exit 2)
+        if: steps.bump.outputs.exit_code == '2'
+        run: echo "::notice::bump-doc-versions found nothing to change (idempotent no-op)."
+
+      - name: Validation error (exit 3)
+        if: steps.bump.outputs.exit_code == '3'
+        run: |
+          echo "::error::bump-doc-versions reported a validation error (exit 3). See the previous step for details."
+          exit 1
+
+      - name: Unexpected error
+        if: >-
+          steps.bump.outputs.exit_code != '0' &&
+          steps.bump.outputs.exit_code != '2' &&
+          steps.bump.outputs.exit_code != '3'
+        run: |
+          echo "::error::bump-doc-versions exited with code ${{ steps.bump.outputs.exit_code }}."
+          exit 1
+
+      - name: Build PR body
+        if: steps.bump.outputs.exit_code == '0' && !inputs.dry_run
+        working-directory: repo
+        env:
+          BODY_STYLE: ${{ inputs.pr_body_style }}
+        run: |
+          node ../actions-tools/bump-doc-versions/build-pr-body.mjs \
+            --report /tmp/bump-report.json \
+            --out    /tmp/pr-body.md \
+            --style  "$BODY_STYLE"
+
+      - name: Commit, push, open/update PR
+        if: steps.bump.outputs.exit_code == '0' && !inputs.dry_run
+        working-directory: repo
+        env:
+          GH_TOKEN:    ${{ secrets.github_token }}
+          BASE_BRANCH: ${{ inputs.base_branch }}
+          HEAD_BRANCH: ${{ inputs.head_branch }}
+          PR_TITLE:    ${{ inputs.pr_title }}
+        run: |
+          git config user.name  'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
+          git checkout -B "$HEAD_BRANCH"
+          git add -A
+          if git diff --cached --quiet; then
+            echo "::notice::Working tree has no changes after script (branch already up to date)."
+            exit 0
+          fi
+          git commit -m "$PR_TITLE"
+          git push --force-with-lease origin "$HEAD_BRANCH"
+
+          existing_pr=$(gh pr list \
+            --head "$HEAD_BRANCH" \
+            --base "$BASE_BRANCH" \
+            --state open \
+            --json number \
+            --jq '.[0].number' || echo "")
+          if [ -n "$existing_pr" ]; then
+            echo "::notice::Updating existing PR #$existing_pr"
+            gh pr edit "$existing_pr" \
+              --title "$PR_TITLE" \
+              --body-file /tmp/pr-body.md
+          else
+            gh pr create \
+              --base  "$BASE_BRANCH" \
+              --head  "$HEAD_BRANCH" \
+              --title "$PR_TITLE" \
+              --body-file /tmp/pr-body.md
+          fi
+
+      - name: Upload JSON report
+        if: always() && steps.bump.outputs.exit_code != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: bump-doc-versions-report
+          path: /tmp/bump-report.json
+          if-no-files-found: ignore
+
+      - name: Dry-run summary
+        if: inputs.dry_run
+        run: |
+          echo "::notice::Dry run complete. No commit, push, or PR was created."
+          if [ -f /tmp/bump-report.json ]; then
+            echo "----- bump-report.json -----"
+            cat /tmp/bump-report.json
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ test/temp/
 .translation-prompt.txt
 coverage/
 .DS_store
+
+# Working scratch directory (design docs, notes, etc.)
+tmp/

--- a/README.md
+++ b/README.md
@@ -33,6 +33,15 @@ Automatically translates English documentation to Japanese using Claude Code Git
 | **Location**    | [`auto-translate-markdown-script/`](./auto-translate-markdown-script/) |
 | **Setup guide** | [View documentation](./auto-translate-markdown-script/README.md)       |
 
+### 🔢 Bump doc versions
+
+Anchored, scope-limited patch-version bumper for the ScalarDB and ScalarDL docs. Rewrites Maven/Gradle coordinates, Docker image tags, Javadoc URLs, GitHub release-tag URLs, JAR filenames, and shell env vars across the internal source-of-truth repo and its public docs-site mirror. Opens a PR for a human to review — never auto-merges.
+
+| Field           | Details                                                                |
+|-----------------|------------------------------------------------------------------------|
+| **Location**    | [`bump-doc-versions/`](./bump-doc-versions/)                           |
+| **Setup guide** | [View documentation](./bump-doc-versions/README.md)                    |
+
 ## 🚀 Getting started
 
 Follow these simple steps to integrate any of these actions into your repository.
@@ -52,6 +61,7 @@ For detailed setup and usage instructions, see the individual README files:
 - **[`auto-translate-markdown-script/README.md`](./auto-translate-markdown-script/README.md):** Translation workflow setup
 - **[`auto-docs-script/README.md`](./auto-docs-script/README.md):** Documentation generation
 - **[`auto-pr-script/README.md`](./auto-pr-script/README.md):** PR automation
+- **[`bump-doc-versions/README.md`](./bump-doc-versions/README.md):** ScalarDB/ScalarDL patch-version bump automation
 
 ## 🛠️ Development
 

--- a/bump-doc-versions/README.md
+++ b/bump-doc-versions/README.md
@@ -1,0 +1,149 @@
+# 🔢 Bump doc versions
+
+Anchored, scope-limited version-string bumper for the ScalarDB and ScalarDL docs. Rewrites Maven/Gradle coordinates, Docker image tags, Javadoc URLs, GitHub release-tag URLs, JAR filenames, and shell env vars — never a bare `X.Y.Z` search.
+
+Ships as a **Node script** (runnable locally) and a **reusable workflow** callable from either the internal source-of-truth repo (`docs-internal-*`) or the public docs-site repo (`docs-*`).
+
+## 📁 Layout
+
+```
+bump-doc-versions/
+├── bump-doc-versions.mjs         # main CLI
+├── build-pr-body.mjs             # renders a PR body from the JSON report
+├── detect-classname-diff.mjs     # parses className diffs (used by the public caller)
+├── lib/
+│   ├── patterns.mjs              # P1–P10 anchored pattern engine
+│   ├── scope.mjs                 # file walker + .version-bump-ignore
+│   └── docusaurus-config.mjs     # className read/write for docusaurus.config.js
+├── products/
+│   ├── scalardb.json             # ScalarDB artifact allowlists
+│   └── scalardl.json             # ScalarDL artifact allowlists
+├── sample-usage.yaml             # example caller workflows for each repo
+└── README.md
+```
+
+## 🧰 Local usage
+
+Requires Node.js 20+. No `npm install` needed — the script is zero-dependency.
+
+```bash
+node bump-doc-versions/bump-doc-versions.mjs \
+  --product scalardb \
+  --repo    internal \
+  --minor   3.17 \
+  --to      3.17.4 \
+  [--from   3.17.3] \
+  [--root   /path/to/docs-internal-scalardb] \
+  [--dry-run] \
+  [--json-report /tmp/report.json]
+```
+
+### Flags
+
+| Flag | Required | Description |
+|---|---|---|
+| `--product` | yes | `scalardb` or `scalardl`. Selects the product config file under `products/`. |
+| `--repo` | yes | `internal` or `public`. Selects the file-scope map (see below). |
+| `--minor` | yes | `3.17`, `3.18`, …, or `current` (only valid with `--repo public`). |
+| `--to` | yes | Target full version `X.Y.Z`. Must satisfy `X.Y === --minor` (or `X.Y === current-minor` when `--minor current`). |
+| `--from` | no | Source version. Auto-derived from `className` (public) or the first anchored match under `docs/en-us/**` (internal) when omitted. Errors out if the auto-derivation is ambiguous. |
+| `--root` | no | Root of the target repo. Defaults to `.`. |
+| `--dry-run` | no | Do not write files or update `className`. Report only. |
+| `--json-report <path>` | no | Write a machine-readable report to `<path>`. |
+| `--help` | no | Print usage. |
+
+### Exit codes
+
+| Code | Meaning |
+|---|---|
+| `0` | Success. Files were written (or a dry-run rendered a non-empty report). |
+| `2` | No changes needed (idempotent no-op). |
+| `3` | Validation error — bad flags, mismatched `--from`, ambiguous derivation, etc. |
+| `1` | Unexpected error. |
+
+### File-scope map
+
+| `--repo` | `--minor` | Scope walked |
+|---|---|---|
+| `internal` | `3.17` | `docs/en-us/**`, `docs/ja-jp/**` |
+| `public` | `3.17` (non-current) | `versioned_docs/version-3.17/**`, `i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.17/**` |
+| `public` | `current` | `docs/**`, `i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/current/**`, plus the `className` field of the `current` entry in `docusaurus.config.js` |
+
+### Anchored patterns
+
+All ten patterns are enumerated in the design doc. In short:
+
+| ID | What it matches | Example |
+|---|---|---|
+| `P1` | Maven/Gradle coordinate | `com.scalar-labs:scalardb-cluster-java-client-sdk:3.17.2` |
+| `P2` | `<version>X.Y.Z</version>` (with `com.scalar-labs` nearby) | inside a `<dependency>` block |
+| `P3` | Docker image tag | `ghcr.io/scalar-labs/scalardb-cluster-schema-loader:3.17.2` |
+| `P4` | Release tag URL | `github.com/scalar-labs/scalardb/releases/tag/v3.17.2` |
+| `P5` | Release download URL | `github.com/scalar-labs/scalardb/releases/download/v3.17.2/…` |
+| `P6` | Javadoc URL | `javadoc.io/doc/com.scalar-labs/scalardb-sql/3.17.2/…` |
+| `P7` | JAR filename | `scalardb-cluster-schema-loader-3.17.2-all.jar` |
+| `P8` | Shell env-var assignment | `SCALAR_DB_CLUSTER_VERSION=3.17.2` |
+| `P9` | Analytics Spark trailing version | `com.scalar-labs:scalardb-analytics-spark-all-3.5_2.12:3.17.2` (via `mavenArtifactsRegex`) |
+| `P10` | Bare `X.Y.Z` in prose | `"ScalarDB 3.16.5, 3.17.3, or 3.18.0"` — gated on the file having at least one P1–P9 same-minor match |
+
+**Scope guard:** for every pattern except P10, only occurrences where `X.Y === --minor` are rewritten. On the `3.17` branch, `3.16.5` and `3.18.0` in a prose line are left alone.
+
+### Ignore markers
+
+Three mechanisms, applied in this order:
+
+1. **Baked-in path exclusions** — `helm-charts/**`, `scalar-kubernetes/**`, `node_modules/**`, `.git/**`, `build/**`, `dist/**`.
+2. **Repo-level `.version-bump-ignore`** — gitignore-syntax glob list at the repo root.
+3. **In-file markers:**
+   - `<!-- version-bump: skip-file -->` anywhere in a file → the whole file is skipped.
+   - `<!-- version-bump: skip -->` on a line → the following line is skipped.
+
+### Product configuration
+
+The set of Maven artifacts, Docker images, release repos, JAR bases, and env-var prefixes that count as "ScalarDB" or "ScalarDL" is defined in `products/<product>.json`. Adding a new artifact requires a PR to this repo — this is deliberate: the tool should never silently rewrite something it doesn't understand.
+
+## 🤖 GitHub Actions usage
+
+The reusable workflow lives at [`.github/workflows/bump-doc-versions-reusable.yaml`](../.github/workflows/bump-doc-versions-reusable.yaml).
+
+See [`sample-usage.yaml`](./sample-usage.yaml) for ready-to-copy caller workflows:
+
+- **Internal repo caller** — `docs-internal-scalardb/.github/workflows/bump-doc-versions.yml`. Accepts a `repository_dispatch` from the public repo, or a manual `workflow_dispatch`, and runs the reusable workflow against the matching version branch.
+- **Public repo caller** — `docs-scalardb/.github/workflows/trigger-version-bump.yml`. Detects a `className` change in `docusaurus.config.js` on push to `main`, extracts `(minor, from, to)`, `repository_dispatch`es into the internal repo, and runs a safety-net bump on the public repo itself.
+
+### Tokens
+
+The reusable workflow accepts one secret, `github_token`, with the following required permissions on the caller repo:
+
+- `contents: write` — to push the bump commit.
+- `pull-requests: write` — to open or update the PR.
+
+For **same-repo operations** (the internal caller pushing a bump PR to its own repo), the built-in `GITHUB_TOKEN` is sufficient — pass it via `secrets: inherit` or `github_token: ${{ secrets.GITHUB_TOKEN }}`.
+
+For the **cross-repo `repository_dispatch`** in the public-repo caller, a personal access token (or GitHub App installation token) with `contents: write` on the target internal repo is required. Store it as `BUMP_DISPATCH_PAT` in the public repo's secrets. See `sample-usage.yaml` for the exact usage.
+
+## 🧪 Testing
+
+A safe way to test against a branch of `docs-internal-scalardb` without committing to it:
+
+```bash
+# Set up an isolated worktree for the 3.17 branch
+git -C /path/to/docs-internal-scalardb worktree add /tmp/dis-3.17 origin/3.17
+
+# Dry-run against it
+node bump-doc-versions/bump-doc-versions.mjs \
+  --product scalardb \
+  --repo    internal \
+  --minor   3.17 \
+  --from    3.17.2 \
+  --to      3.17.99 \
+  --dry-run \
+  --root    /tmp/dis-3.17 \
+  --json-report /tmp/dis-3.17-report.json
+
+# Inspect the report
+jq '.totals, .byPattern' /tmp/dis-3.17-report.json
+
+# Clean up
+git -C /path/to/docs-internal-scalardb worktree remove /tmp/dis-3.17
+```

--- a/bump-doc-versions/build-pr-body.mjs
+++ b/bump-doc-versions/build-pr-body.mjs
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+// Build a Markdown PR body from a bump-doc-versions JSON report.
+// Emits the design §8 body verbatim for internal-repo PRs and a shorter one
+// for public-repo safety-net PRs.
+
+import { promises as fs } from 'node:fs';
+import { parseArgs } from 'node:util';
+
+async function main() {
+  const { values } = parseArgs({
+    options: {
+      report: { type: 'string' },
+      out:    { type: 'string' },
+      style:  { type: 'string', default: 'internal' }, // internal | public-safety-net
+    },
+  });
+  if (!values.report || !values.out) {
+    console.error('Usage: build-pr-body.mjs --report <json> --out <md> [--style internal|public-safety-net]');
+    process.exit(2);
+  }
+
+  const report = JSON.parse(await fs.readFile(values.report, 'utf8'));
+  const body =
+    values.style === 'public-safety-net'
+      ? renderSafetyNet(report)
+      : renderInternal(report);
+  await fs.writeFile(values.out, body, 'utf8');
+}
+
+function renderInternal(r) {
+  return `## Description
+
+This PR updates documentation references throughout the ${r.product === 'scalardb' ? 'ScalarDB' : 'ScalarDL'} \`${r.minor}\` docs to use version \`${r.to}\` instead of \`${r.from}\`. The changes ensure that all code snippets, dependency instructions, download links, Docker image tags, and Javadoc URLs point to the latest release.
+
+## Related issues and/or PRs
+
+N/A
+
+## Changes made
+
+- Changed the patch version to the latest version (\`${r.from}\` → \`${r.to}\`).
+
+## Checklist
+
+- [x] I have updated the Japanese version of this documentation.
+- [x] I have updated all applicable versions of the documentation.
+- [ ] I have checked that my documentation looks as expected on a locally built version of the docs site.
+- [x] Any remaining open issues linked to this PR are documented and up-to-date.
+- [x] Any dependent changes in other PRs have been merged and published.
+
+## Additional notes
+
+Opened automatically by [\`bump-doc-versions\`](https://github.com/josh-wong/actions/tree/main/bump-doc-versions) in response to a \`className\` update on \`main\` of the public docs repo.
+
+${renderVerification(r)}
+`;
+}
+
+function renderSafetyNet(r) {
+  return `## Description
+
+Safety-net patch-version bump opened automatically after a \`className\` change on \`main\`. This covers files in the public repo that don't sync from the internal repo. If the internal-repo sync PR arrives first, this bot will notice the no-op and skip re-opening.
+
+## Changes made
+
+- Changed the patch version to the latest version (\`${r.from}\` → \`${r.to}\`).
+
+${renderVerification(r)}
+`;
+}
+
+function renderVerification(r) {
+  const lines = [];
+  lines.push('## Verification report');
+  lines.push('');
+  lines.push(`- **Product:** \`${r.product}\``);
+  lines.push(`- **Repo scope:** \`${r.repo}\``);
+  lines.push(`- **Minor:** \`${r.minor}\`${r.minorRequested && r.minorRequested !== r.minor ? ` (requested: \`${r.minorRequested}\`)` : ''}`);
+  lines.push(`- **From → To:** \`${r.from}\` → \`${r.to}\``);
+  lines.push(`- **Dry run:** ${r.dryRun ? 'yes' : 'no'}`);
+  lines.push(`- **Files changed:** ${r.totals.files}`);
+  lines.push(`- **Total replacements:** ${r.totals.replacements}`);
+  if (r.classNameUpdated?.changed) {
+    lines.push(`- **\`className\` updated:** \`${r.classNameUpdated.from}\` → \`${r.classNameUpdated.to}\``);
+  }
+  lines.push('');
+  if (Object.keys(r.byPattern || {}).length) {
+    lines.push('### By pattern');
+    lines.push('');
+    lines.push('| Pattern | Count |');
+    lines.push('|---|---|');
+    for (const [p, c] of Object.entries(r.byPattern).sort()) {
+      lines.push(`| \`${p}\` | ${c} |`);
+    }
+    lines.push('');
+  }
+  if ((r.byFile || []).length) {
+    lines.push('<details>');
+    lines.push('<summary>Files changed (' + r.byFile.length + ')</summary>');
+    lines.push('');
+    lines.push('| File | Replacements | Patterns |');
+    lines.push('|---|---|---|');
+    for (const f of r.byFile) {
+      const pats = Object.entries(f.patterns).sort().map(([p, c]) => `${p}×${c}`).join(', ');
+      lines.push(`| \`${f.path}\` | ${f.replacements} | ${pats} |`);
+    }
+    lines.push('');
+    lines.push('</details>');
+    lines.push('');
+  }
+  if ((r.skippedFiles || []).length) {
+    lines.push('<details>');
+    lines.push('<summary>Skipped files (' + r.skippedFiles.length + ')</summary>');
+    lines.push('');
+    for (const s of r.skippedFiles) {
+      lines.push(`- \`${s.path}\` — ${s.reason}`);
+    }
+    lines.push('');
+    lines.push('</details>');
+    lines.push('');
+  }
+  if ((r.unknownArtifactsSeen || []).length) {
+    lines.push('> :warning: Unknown artifacts observed (add to the product config if legitimate): ' + r.unknownArtifactsSeen.map((a) => `\`${a}\``).join(', '));
+    lines.push('');
+  }
+  return lines.join('\n');
+}
+
+main().catch((e) => {
+  console.error(e && e.stack ? e.stack : String(e));
+  process.exit(1);
+});

--- a/bump-doc-versions/bump-doc-versions.mjs
+++ b/bump-doc-versions/bump-doc-versions.mjs
@@ -1,0 +1,302 @@
+#!/usr/bin/env node
+// bump-doc-versions — anchored, scope-limited version-string bumper for ScalarDB
+// and ScalarDL docs. See the version-bump-automation design doc for the full
+// specification.
+//
+// Exit codes:
+//   0  success — writes done (or dry-run rendered a non-empty report)
+//   2  no changes needed (idempotent no-op)
+//   3  validation error (bad flags, mismatched --from, etc.)
+//   1  unexpected error
+
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parseArgs } from 'node:util';
+
+import { matchFile, buildScanners } from './lib/patterns.mjs';
+import { getFileScope, loadIgnoreFile, walkScope } from './lib/scope.mjs';
+import {
+  getClassNameFor,
+  getCurrentMinor,
+  updateClassName,
+} from './lib/docusaurus-config.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+async function main() {
+  const { values } = parseArgs({
+    options: {
+      product:       { type: 'string' },
+      repo:          { type: 'string' },
+      minor:         { type: 'string' },
+      to:            { type: 'string' },
+      from:          { type: 'string' },
+      root:          { type: 'string', default: '.' },
+      'dry-run':     { type: 'boolean', default: false },
+      'json-report': { type: 'string' },
+      help:          { type: 'boolean', short: 'h', default: false },
+    },
+  });
+
+  if (values.help) {
+    printUsage();
+    process.exit(0);
+  }
+
+  // ── Validate required flags ───────────────────────────────────────────────
+  const missing = ['product', 'repo', 'minor', 'to'].filter((k) => !values[k]);
+  if (missing.length) {
+    fail(3, `Missing required flag(s): ${missing.map((m) => `--${m}`).join(', ')}`);
+  }
+  if (!['scalardb', 'scalardl'].includes(values.product)) {
+    fail(3, `--product must be scalardb or scalardl (got: ${values.product})`);
+  }
+  if (!['internal', 'public'].includes(values.repo)) {
+    fail(3, `--repo must be internal or public (got: ${values.repo})`);
+  }
+  const toParts = values.to.split('.');
+  if (toParts.length !== 3 || !toParts.every((p) => /^\d+$/.test(p))) {
+    fail(3, `--to must be X.Y.Z (got: ${values.to})`);
+  }
+
+  const root = path.resolve(values.root);
+  const cfgPath = path.join(__dirname, 'products', `${values.product}.json`);
+  const config = JSON.parse(await fs.readFile(cfgPath, 'utf8'));
+
+  // ── Resolve effectiveMinor (handles --minor current) ──────────────────────
+  let effectiveMinor = values.minor;
+  let publicCurrentMinor = null;
+  let isCurrent = false;
+
+  if (values.repo === 'public') {
+    try {
+      publicCurrentMinor = await getCurrentMinor(root);
+    } catch (e) {
+      fail(3, `Could not read docusaurus.config.js under ${root}: ${e.message}`);
+    }
+    if (!publicCurrentMinor) {
+      fail(3, `Could not parse a 'current' className from docusaurus.config.js`);
+    }
+    if (values.minor === 'current') {
+      effectiveMinor = publicCurrentMinor;
+      isCurrent = true;
+    } else {
+      isCurrent = values.minor === publicCurrentMinor;
+    }
+  } else if (values.minor === 'current') {
+    fail(3, `--minor current is only valid with --repo public`);
+  }
+
+  const toMinor = `${toParts[0]}.${toParts[1]}`;
+  if (toMinor !== effectiveMinor) {
+    fail(3, `--to ${values.to} has minor ${toMinor}, does not match --minor ${effectiveMinor}`);
+  }
+
+  // ── Derive --from if omitted ──────────────────────────────────────────────
+  let fromVer = values.from;
+  if (!fromVer) {
+    if (values.repo === 'public') {
+      fromVer = await getClassNameFor(root, values.minor);
+      if (!fromVer) {
+        fail(3, `Could not derive --from from className for entry ${values.minor}`);
+      }
+    } else {
+      const derived = await deriveFromInternal(root, effectiveMinor, config);
+      if (derived.error) fail(3, derived.error);
+      fromVer = derived.version;
+      if (!fromVer) {
+        // Empty tree for this minor is a legitimate no-op — bail cleanly.
+        console.log(
+          `No anchored ${values.product} version references found under docs/en-us for minor ${effectiveMinor}; nothing to do.`,
+        );
+        await maybeWriteEmptyReport(values, effectiveMinor, null);
+        process.exit(2);
+      }
+    }
+  }
+
+  const fromParts = fromVer.split('.');
+  if (fromParts.length !== 3 || `${fromParts[0]}.${fromParts[1]}` !== effectiveMinor) {
+    fail(3, `--from ${fromVer} does not belong to minor ${effectiveMinor}`);
+  }
+  if (fromVer === values.to) {
+    console.log(`--from and --to are both ${fromVer}; nothing to do.`);
+    await maybeWriteEmptyReport(values, effectiveMinor, fromVer);
+    process.exit(2);
+  }
+
+  // ── Walk file scope ───────────────────────────────────────────────────────
+  const scopePaths = getFileScope(values.repo, effectiveMinor, isCurrent);
+  const ignoreMatcher = await loadIgnoreFile(root);
+
+  const report = {
+    product: values.product,
+    repo: values.repo,
+    minor: effectiveMinor,
+    minorRequested: values.minor,
+    from: fromVer,
+    to: values.to,
+    dryRun: values['dry-run'],
+    scope: scopePaths,
+    totals: { files: 0, replacements: 0 },
+    byPattern: {},
+    byFile: [],
+    unknownArtifactsSeen: [], // reserved for a future pass
+    skippedFiles: [],
+    classNameUpdated: null,
+  };
+
+  for await (const abs of walkScope(root, scopePaths, ignoreMatcher)) {
+    const content = await fs.readFile(abs, 'utf8');
+    const { matches, skipped } = matchFile(content, effectiveMinor, config);
+    const rel = path.relative(root, abs).split(path.sep).join('/');
+
+    if (skipped) {
+      report.skippedFiles.push({ path: rel, reason: skipped });
+      continue;
+    }
+    if (matches.length === 0) continue;
+
+    // Apply substitutions in reverse offset order so earlier offsets stay valid.
+    let next = content;
+    const patCounts = {};
+    for (const m of matches.slice().reverse()) {
+      const replacement = m.oldStr.replace(m.oldVer, values.to);
+      next = next.slice(0, m.offset) + replacement + next.slice(m.offset + m.length);
+      patCounts[m.pattern] = (patCounts[m.pattern] || 0) + 1;
+    }
+
+    for (const [p, c] of Object.entries(patCounts)) {
+      report.byPattern[p] = (report.byPattern[p] || 0) + c;
+      report.totals.replacements += c;
+    }
+    report.byFile.push({ path: rel, patterns: patCounts, replacements: matches.length });
+    report.totals.files += 1;
+
+    if (!values['dry-run'] && next !== content) {
+      await fs.writeFile(abs, next, 'utf8');
+    }
+  }
+
+  // ── Update className on the public repo, current-minor path ───────────────
+  if (values.repo === 'public' && isCurrent) {
+    // In the primary flow the human has already edited className. In the
+    // safety-net / manual-dispatch path this may still need updating.
+    const cnKey = values.minor === 'current' ? 'current' : effectiveMinor;
+    const cn = await updateClassName(root, cnKey, values.to, values['dry-run']);
+    report.classNameUpdated = cn;
+    if (cn.changed) {
+      report.byPattern.CLASSNAME = (report.byPattern.CLASSNAME || 0) + 1;
+      report.byFile.push({
+        path: 'docusaurus.config.js',
+        patterns: { CLASSNAME: 1 },
+        replacements: 1,
+      });
+      report.totals.files += 1;
+      report.totals.replacements += 1;
+    }
+  }
+
+  // ── Emit JSON report ─────────────────────────────────────────────────────
+  if (values['json-report']) {
+    await fs.writeFile(values['json-report'], JSON.stringify(report, null, 2), 'utf8');
+  }
+
+  // ── Console summary ──────────────────────────────────────────────────────
+  const verb = values['dry-run'] ? 'Would bump' : 'Bumped';
+  console.log(
+    `${verb} ${fromVer} → ${values.to} in ${report.totals.files} file(s), ` +
+      `${report.totals.replacements} replacement(s)`,
+  );
+  if (Object.keys(report.byPattern).length) {
+    const brk = Object.entries(report.byPattern)
+      .sort()
+      .map(([p, c]) => `${p}=${c}`)
+      .join(' ');
+    console.log(`  by pattern: ${brk}`);
+  }
+
+  if (report.totals.replacements === 0) process.exit(2);
+  process.exit(0);
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+async function deriveFromInternal(root, minor, config) {
+  const scanners = buildScanners(config);
+  const seen = new Set();
+  for await (const abs of walkScope(root, ['docs/en-us'], () => false)) {
+    const content = await fs.readFile(abs, 'utf8');
+    for (const s of scanners) {
+      s.regex.lastIndex = 0;
+      let m;
+      while ((m = s.regex.exec(content)) !== null) {
+        if (m[1] === minor) seen.add(`${m[1]}.${m[2]}`);
+      }
+    }
+  }
+  if (seen.size === 0) return { version: null };
+  if (seen.size > 1) {
+    return {
+      error:
+        `Ambiguous --from: multiple X.Y.Z values found under docs/en-us for minor ${minor}: ` +
+        [...seen].sort().join(', ') +
+        `. Pass --from explicitly.`,
+    };
+  }
+  return { version: [...seen][0] };
+}
+
+async function maybeWriteEmptyReport(values, minor, fromVer) {
+  if (!values['json-report']) return;
+  const empty = {
+    product: values.product,
+    repo: values.repo,
+    minor,
+    minorRequested: values.minor,
+    from: fromVer,
+    to: values.to,
+    dryRun: values['dry-run'],
+    totals: { files: 0, replacements: 0 },
+    byPattern: {},
+    byFile: [],
+    unknownArtifactsSeen: [],
+    skippedFiles: [],
+    classNameUpdated: null,
+  };
+  await fs.writeFile(values['json-report'], JSON.stringify(empty, null, 2), 'utf8');
+}
+
+function fail(code, msg) {
+  console.error(`bump-doc-versions: ${msg}`);
+  process.exit(code);
+}
+
+function printUsage() {
+  process.stdout.write(`\
+bump-doc-versions — bump anchored patch-version strings in ScalarDB / ScalarDL docs
+
+Usage:
+  bump-doc-versions \\
+    --product scalardb|scalardl \\
+    --repo    internal|public \\
+    --minor   3.17|current \\
+    --to      3.17.4 \\
+    [--from   3.17.3] \\
+    [--root   .] \\
+    [--dry-run] \\
+    [--json-report /tmp/report.json]
+
+Exit codes:
+  0  changes applied (or dry-run rendered a non-empty report)
+  2  nothing to do (idempotent no-op)
+  3  validation error
+  1  unexpected error
+`);
+}
+
+main().catch((e) => {
+  console.error(e && e.stack ? e.stack : String(e));
+  process.exit(1);
+});

--- a/bump-doc-versions/detect-classname-diff.mjs
+++ b/bump-doc-versions/detect-classname-diff.mjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+// detect-classname-diff — parses docusaurus.config.js from two revisions and
+// emits a JSON array of { minor, from, to } for every version entry whose
+// `className` changed. Refuses to emit minor-spanning bumps.
+//
+// Used by the public-repo caller workflow to drive both the cross-repo
+// dispatch into `docs-internal-<product>` and the local safety-net bump.
+// See design §6.3.1.
+//
+// Usage:
+//   node detect-classname-diff.mjs --before <file> --after <file>
+//
+// Prints the JSON array on stdout. Exit code:
+//   0 — parsed successfully (may print `[]`)
+//   3 — validation error (bad flags / cannot read files)
+
+import { promises as fs } from 'node:fs';
+import { parseArgs } from 'node:util';
+
+// Matches either `current:` or `'3.17':` / `"3.17":` followed by a flat
+// object literal containing a `className: 'X.Y.Z'` field. `[^{}]*?` restricts
+// the search to a single non-nested block so unrelated braces further down
+// the file cannot leak in. Ignores classNames that are not pure `[0-9.]+`
+// (e.g. the commented-out `'X.X.X'` placeholder in the template).
+const ENTRY_RX =
+  /(current|['"](\d+\.\d+)['"])\s*:\s*\{[^{}]*?className\s*:\s*['"](\d+\.\d+\.\d+)['"]/g;
+
+function parseVersions(text) {
+  const out = {};
+  ENTRY_RX.lastIndex = 0;
+  let m;
+  while ((m = ENTRY_RX.exec(text)) !== null) {
+    const key = m[1] === 'current' ? 'current' : m[2];
+    out[key] = m[3];
+  }
+  return out;
+}
+
+async function main() {
+  const { values } = parseArgs({
+    options: {
+      before: { type: 'string' },
+      after:  { type: 'string' },
+    },
+  });
+  if (!values.before || !values.after) {
+    console.error('Usage: detect-classname-diff.mjs --before <file> --after <file>');
+    process.exit(3);
+  }
+
+  // `before` is allowed to be missing (initial commit): treat as no-entries.
+  let beforeText = '';
+  try {
+    beforeText = await fs.readFile(values.before, 'utf8');
+  } catch (e) {
+    if (e.code !== 'ENOENT') throw e;
+  }
+  const afterText = await fs.readFile(values.after, 'utf8');
+
+  const before = parseVersions(beforeText);
+  const after = parseVersions(afterText);
+
+  const bumps = [];
+  for (const [key, to] of Object.entries(after)) {
+    const from = before[key];
+    if (!from || from === to) continue;
+    const [fromMajor, fromMinor] = from.split('.');
+    const [toMajor, toMinor] = to.split('.');
+    if (`${fromMajor}.${fromMinor}` !== `${toMajor}.${toMinor}`) {
+      console.error(
+        `warning: skipping ${key}: ${from} -> ${to} (minor-spanning bump not supported by this workflow)`,
+      );
+      continue;
+    }
+    const minor = key === 'current' ? `${toMajor}.${toMinor}` : key;
+    bumps.push({ minor, from, to });
+  }
+  process.stdout.write(JSON.stringify(bumps));
+}
+
+main().catch((e) => {
+  console.error(e && e.stack ? e.stack : String(e));
+  process.exit(1);
+});

--- a/bump-doc-versions/lib/docusaurus-config.mjs
+++ b/bump-doc-versions/lib/docusaurus-config.mjs
@@ -1,0 +1,61 @@
+// Minimal reader/updater for the `versions:` block in a Docusaurus config.
+//
+// We deliberately avoid a full JS parser. The `versions` object literal in
+// docusaurus.config.js is stable enough that a targeted regex is both simpler
+// and more robust to unrelated file changes. Each entry looks like:
+//
+//   current: { label: '...', className: '3.18.0', ... }
+//   '3.17':  { label: '3.17',  className: '3.17.3', ... }
+//
+// Only the `className` field is read/written — this is the single source of
+// truth for "current patch of each minor" per design §1d.
+
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+function keyPattern(minorKey) {
+  if (minorKey === 'current') return 'current';
+  return `['"]${minorKey.replace(/\./g, '\\.')}['"]`;
+}
+
+function entryRegex(minorKey) {
+  // `[^{}]*?` restricts the search to a single flat object literal (no nested
+  // braces). Docusaurus version entries are flat objects, so this is safe.
+  return new RegExp(
+    `(${keyPattern(minorKey)}\\s*:\\s*\\{[^{}]*?className\\s*:\\s*['"])([\\d.]+)(['"])`
+  );
+}
+
+export async function getClassNameFor(root, minorKey) {
+  const cfgPath = path.join(root, 'docusaurus.config.js');
+  const text = await fs.readFile(cfgPath, 'utf8');
+  const m = text.match(entryRegex(minorKey));
+  return m ? m[2] : null;
+}
+
+/**
+ * Returns the "X.Y" of the current entry's className, or null if not found.
+ */
+export async function getCurrentMinor(root) {
+  const cn = await getClassNameFor(root, 'current');
+  if (!cn) return null;
+  const parts = cn.split('.');
+  if (parts.length < 2) return null;
+  return `${parts[0]}.${parts[1]}`;
+}
+
+/**
+ * Rewrites the className field for the given entry to `newVer`. Returns
+ * `{ changed, from, to }`.
+ */
+export async function updateClassName(root, minorKey, newVer, dryRun) {
+  const cfgPath = path.join(root, 'docusaurus.config.js');
+  const text = await fs.readFile(cfgPath, 'utf8');
+  const rx = entryRegex(minorKey);
+  const m = text.match(rx);
+  if (!m) return { changed: false, from: null, to: newVer };
+  if (m[2] === newVer) return { changed: false, from: m[2], to: newVer };
+  const next = text.replace(rx, `$1${newVer}$3`);
+  if (!dryRun) await fs.writeFile(cfgPath, next, 'utf8');
+  return { changed: true, from: m[2], to: newVer };
+}

--- a/bump-doc-versions/lib/patterns.mjs
+++ b/bump-doc-versions/lib/patterns.mjs
@@ -1,0 +1,258 @@
+// Anchored pattern matcher for bump-doc-versions.
+//
+// Implements P1–P10 from the version-bump-automation design doc §4.1.
+// Each match carries { pattern, offset, length, oldStr, oldVer, line } so the caller can
+// apply substitutions in reverse offset order.
+//
+// Scope guard: for every pattern except P10, only rewrites where matched X.Y === --minor.
+// P10 gate: only rewrites bare X.Y.Z if the same file also contains a P1–P9 same-minor match
+// (per design §6.1.4, which supersedes the tighter same-line wording in §4.1).
+
+const escRx = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+/**
+ * Builds anchored scanners P1, P3, P4, P5, P6, P7, P8 from a product config.
+ * Each scanner is { name, regex } where the regex captures (X.Y) in group 1 and (Z) in group 2.
+ * P2 and P10 are handled separately because they need context (proximity / file-level gate).
+ */
+export function buildScanners(config) {
+  const mavenParts = [
+    ...(config.mavenArtifacts || []).map(escRx),
+    ...(config.mavenArtifactsRegex || []), // already regex
+  ];
+  const mavenGroup = mavenParts.length ? `(?:${mavenParts.join('|')})` : null;
+  const ghcrGroup = (config.ghcrImages || []).length
+    ? `(?:${config.ghcrImages.map(escRx).join('|')})`
+    : null;
+  const releaseGroup = (config.releaseRepos || []).length
+    ? `(?:${config.releaseRepos.map(escRx).join('|')})`
+    : null;
+  const jarGroup = (config.jarBases || []).length
+    ? `(?:${config.jarBases.map(escRx).join('|')})`
+    : null;
+  const envGroup = (config.envVarPrefixes || []).length
+    ? `(?:${config.envVarPrefixes.map(escRx).join('|')})`
+    : null;
+
+  const scanners = [];
+
+  if (mavenGroup) {
+    // P1: com.scalar-labs:ARTIFACT:X.Y.Z
+    scanners.push({
+      name: 'P1',
+      regex: new RegExp(`com\\.scalar-labs:${mavenGroup}:(\\d+\\.\\d+)\\.(\\d+)`, 'g'),
+    });
+    // P6: javadoc.io/doc/com.scalar-labs/ARTIFACT/X.Y.Z/
+    scanners.push({
+      name: 'P6',
+      regex: new RegExp(`javadoc\\.io/doc/com\\.scalar-labs/${mavenGroup}/(\\d+\\.\\d+)\\.(\\d+)/`, 'g'),
+    });
+  }
+  if (ghcrGroup) {
+    // P3: ghcr.io/scalar-labs/IMAGE:X.Y.Z
+    scanners.push({
+      name: 'P3',
+      regex: new RegExp(`ghcr\\.io/scalar-labs/${ghcrGroup}:(\\d+\\.\\d+)\\.(\\d+)`, 'g'),
+    });
+  }
+  if (releaseGroup) {
+    // P4: github.com/scalar-labs/REPO/releases/tag/vX.Y.Z
+    scanners.push({
+      name: 'P4',
+      regex: new RegExp(`github\\.com/scalar-labs/${releaseGroup}/releases/tag/v(\\d+\\.\\d+)\\.(\\d+)`, 'g'),
+    });
+    // P5: github.com/scalar-labs/REPO/releases/download/vX.Y.Z
+    scanners.push({
+      name: 'P5',
+      regex: new RegExp(`github\\.com/scalar-labs/${releaseGroup}/releases/download/v(\\d+\\.\\d+)\\.(\\d+)`, 'g'),
+    });
+  }
+  if (jarGroup) {
+    // P7: JARBASE-X.Y.Z(-all)?.jar
+    scanners.push({
+      name: 'P7',
+      regex: new RegExp(`${jarGroup}-(\\d+\\.\\d+)\\.(\\d+)(?:-all)?\\.jar`, 'g'),
+    });
+  }
+  if (envGroup) {
+    // P8: ENVVAR=X.Y.Z
+    scanners.push({
+      name: 'P8',
+      regex: new RegExp(`${envGroup}=(\\d+\\.\\d+)\\.(\\d+)`, 'g'),
+    });
+  }
+
+  return scanners;
+}
+
+// P2: <version>X.Y.Z</version> gated by a <groupId>com.scalar-labs</groupId>
+// occurring within `proximityLines` lines before the match.
+const P2_REGEX = /<version>(\d+\.\d+)\.(\d+)<\/version>/g;
+const P2_GROUP_ID_REGEX = /<groupId>\s*com\.scalar-labs\s*<\/groupId>/;
+
+function hasNearbyScalarLabsGroupId(content, offset, proximityLines) {
+  const before = content.slice(0, offset);
+  const lines = before.split('\n');
+  const start = Math.max(0, lines.length - proximityLines - 1);
+  for (let i = start; i < lines.length; i++) {
+    if (P2_GROUP_ID_REGEX.test(lines[i])) return true;
+  }
+  return false;
+}
+
+function scanP2(content, minor, proximityLines = 6) {
+  const matches = [];
+  P2_REGEX.lastIndex = 0;
+  let m;
+  while ((m = P2_REGEX.exec(content)) !== null) {
+    const xy = m[1];
+    const z = m[2];
+    if (xy !== minor) continue;
+    if (!hasNearbyScalarLabsGroupId(content, m.index, proximityLines)) continue;
+    matches.push({
+      pattern: 'P2',
+      offset: m.index,
+      length: m[0].length,
+      oldStr: m[0],
+      oldVer: `${xy}.${z}`,
+    });
+  }
+  return matches;
+}
+
+function scanP10(content, minor) {
+  // Bare X.Y.Z where X.Y === minor. Word-boundary–anchored so `3.17.30` doesn't collapse to `3.17.3`.
+  const rx = new RegExp(`(?<![\\d.])${escRx(minor)}\\.(\\d+)(?![\\d.])`, 'g');
+  const matches = [];
+  let m;
+  while ((m = rx.exec(content)) !== null) {
+    matches.push({
+      pattern: 'P10',
+      offset: m.index,
+      length: m[0].length,
+      oldStr: m[0],
+      oldVer: `${minor}.${m[1]}`,
+    });
+  }
+  return matches;
+}
+
+/**
+ * Match all patterns in a file's content for the given minor.
+ * Returns { matches: [{pattern, offset, length, oldStr, oldVer, line}], skipped }
+ * Applies file-level and per-line skip markers.
+ */
+export function matchFile(content, minor, config) {
+  // File-level skip
+  if (content.includes('<!-- version-bump: skip-file -->')) {
+    return { matches: [], skipped: 'skip-file' };
+  }
+
+  // Collect P1–P9 matches (P2 handled separately)
+  const scanners = buildScanners(config);
+  const raw = [];
+  for (const s of scanners) {
+    s.regex.lastIndex = 0;
+    let m;
+    while ((m = s.regex.exec(content)) !== null) {
+      const xy = m[1];
+      const z = m[2];
+      if (xy !== minor) continue;
+      raw.push({
+        pattern: s.name,
+        offset: m.index,
+        length: m[0].length,
+        oldStr: m[0],
+        oldVer: `${xy}.${z}`,
+      });
+    }
+  }
+  raw.push(...scanP2(content, minor));
+
+  // Gate P10 on having at least one P1–P9 same-minor match in the file
+  if (raw.length > 0) {
+    const p10 = scanP10(content, minor);
+    // Exclude P10 matches that overlap with any P1–P9 match (avoids double-counting
+    // the bare X.Y.Z that lives inside an anchored URL / coordinate / etc.)
+    const covered = intervals(raw);
+    for (const m of p10) {
+      if (!overlapsAny(m.offset, m.offset + m.length, covered)) {
+        raw.push(m);
+      }
+    }
+  }
+
+  // Attach line numbers (1-based) and apply per-line skip markers.
+  const lineStarts = computeLineStarts(content);
+  const skipLines = collectSkipLines(content);
+
+  const kept = [];
+  for (const m of raw) {
+    const line = binarySearchLine(lineStarts, m.offset);
+    if (skipLines.has(line)) continue;
+    kept.push({ ...m, line });
+  }
+
+  kept.sort((a, b) => a.offset - b.offset);
+  return { matches: kept, skipped: null };
+}
+
+// ── helpers ─────────────────────────────────────────────────────────────────
+
+function intervals(matches) {
+  // Sorted [start, end) list, coalesced
+  const sorted = matches.map((m) => [m.offset, m.offset + m.length]).sort((a, b) => a[0] - b[0]);
+  const out = [];
+  for (const [s, e] of sorted) {
+    if (out.length && s <= out[out.length - 1][1]) {
+      out[out.length - 1][1] = Math.max(out[out.length - 1][1], e);
+    } else {
+      out.push([s, e]);
+    }
+  }
+  return out;
+}
+
+function overlapsAny(start, end, intervalsList) {
+  // Binary search first interval whose end > start
+  let lo = 0;
+  let hi = intervalsList.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >>> 1;
+    if (intervalsList[mid][1] <= start) lo = mid + 1;
+    else hi = mid;
+  }
+  return lo < intervalsList.length && intervalsList[lo][0] < end;
+}
+
+function computeLineStarts(content) {
+  const starts = [0];
+  for (let i = 0; i < content.length; i++) {
+    if (content.charCodeAt(i) === 10) starts.push(i + 1);
+  }
+  return starts;
+}
+
+function binarySearchLine(starts, offset) {
+  // 1-based line number
+  let lo = 0;
+  let hi = starts.length - 1;
+  while (lo < hi) {
+    const mid = (lo + hi + 1) >>> 1;
+    if (starts[mid] <= offset) lo = mid;
+    else hi = mid - 1;
+  }
+  return lo + 1;
+}
+
+function collectSkipLines(content) {
+  // A `<!-- version-bump: skip -->` on line N skips matches on line N+1.
+  const skip = new Set();
+  const lines = content.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].includes('<!-- version-bump: skip -->')) {
+      skip.add(i + 2); // 1-based line after
+    }
+  }
+  return skip;
+}

--- a/bump-doc-versions/lib/scope.mjs
+++ b/bump-doc-versions/lib/scope.mjs
@@ -1,0 +1,160 @@
+// File-scope walker, baked-in path exclusions, and .version-bump-ignore support.
+
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+// Extensions we consider text-like enough to scan for version strings.
+// Binary media (images, fonts) and lockfiles are skipped implicitly.
+const SCANNABLE_EXTENSIONS = new Set([
+  '.md', '.mdx',
+  '.yaml', '.yml',
+  '.json', '.jsonc',
+  '.js', '.mjs', '.cjs', '.ts', '.tsx',
+  '.html', '.xml',
+  '.sh', '.env',
+  '.txt', '.properties',
+  '.gradle', '.groovy', '.kts',
+  '.tf', '.toml',
+]);
+
+// Directory names that are excluded regardless of scope. From design §4.3.
+const EXCLUDED_DIRS = new Set([
+  'helm-charts',
+  'scalar-kubernetes',
+  'node_modules',
+  '.git',
+  'build',
+  'dist',
+]);
+
+/**
+ * Returns the list of scope base directories (relative to repo root) to walk,
+ * per design §6.1.3.
+ *
+ * @param {'internal'|'public'} repoKind
+ * @param {string} minor            The concrete "X.Y" being bumped (e.g. "3.17").
+ * @param {boolean} isCurrent       True if this minor is the public repo's current minor
+ *                                  (or if --minor === "current").
+ */
+export function getFileScope(repoKind, minor, isCurrent) {
+  if (repoKind === 'internal') {
+    return ['docs/en-us', 'docs/ja-jp'];
+  }
+  // public
+  if (isCurrent) {
+    return [
+      'docs',
+      'i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/current',
+    ];
+  }
+  return [
+    `versioned_docs/version-${minor}`,
+    `i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-${minor}`,
+  ];
+}
+
+/**
+ * Loads `.version-bump-ignore` (gitignore-lite) from the repo root, if present.
+ * Returns a predicate `(relPath) => boolean` — true means "ignore this path".
+ *
+ * Supported syntax:
+ *   - Lines starting with `#` are comments.
+ *   - Blank lines are ignored.
+ *   - `*` matches any characters except `/`.
+ *   - `**` matches any characters including `/`.
+ *   - Trailing `/` marks directory patterns.
+ *   - Leading `!` negates (un-ignores) a prior match.
+ */
+export async function loadIgnoreFile(root) {
+  const p = path.join(root, '.version-bump-ignore');
+  let text;
+  try {
+    text = await fs.readFile(p, 'utf8');
+  } catch (e) {
+    if (e.code === 'ENOENT') return () => false;
+    throw e;
+  }
+  const rules = [];
+  for (const raw of text.split(/\r?\n/)) {
+    const line = raw.trim();
+    if (!line || line.startsWith('#')) continue;
+    const negate = line.startsWith('!');
+    const body = negate ? line.slice(1) : line;
+    rules.push({ regex: globToRegex(body), negate });
+  }
+  return (rel) => {
+    let ignored = false;
+    for (const r of rules) {
+      if (r.regex.test(rel)) ignored = !r.negate;
+    }
+    return ignored;
+  };
+}
+
+function globToRegex(glob) {
+  const isDir = glob.endsWith('/');
+  let g = isDir ? glob.slice(0, -1) : glob;
+  // Anchor: patterns starting with `/` are repo-root-relative; otherwise match anywhere.
+  const anchored = g.startsWith('/');
+  if (anchored) g = g.slice(1);
+
+  let rx = '';
+  for (let i = 0; i < g.length; i++) {
+    const c = g[i];
+    if (c === '*') {
+      if (g[i + 1] === '*') {
+        rx += '.*';
+        i++;
+        // Consume trailing slash of `**/`
+        if (g[i + 1] === '/') i++;
+      } else {
+        rx += '[^/]*';
+      }
+    } else if (c === '?') {
+      rx += '[^/]';
+    } else if ('.+^${}()|[]\\'.includes(c)) {
+      rx += '\\' + c;
+    } else {
+      rx += c;
+    }
+  }
+  const prefix = anchored ? '^' : '(?:^|/)';
+  const suffix = isDir ? '(?:/.*)?$' : '(?:/.*)?$';
+  return new RegExp(prefix + rx + suffix);
+}
+
+/**
+ * Walk all files under the given scope paths, honoring baked-in exclusions
+ * and the caller-provided ignore predicate. Yields absolute file paths.
+ */
+export async function* walkScope(root, scopePaths, ignoreMatcher) {
+  for (const rel of scopePaths) {
+    const abs = path.join(root, rel);
+    yield* walkDir(root, abs, ignoreMatcher);
+  }
+}
+
+async function* walkDir(root, dir, ignoreMatcher) {
+  let entries;
+  try {
+    entries = await fs.readdir(dir, { withFileTypes: true });
+  } catch (e) {
+    if (e.code === 'ENOENT') return;
+    throw e;
+  }
+  for (const entry of entries) {
+    const abs = path.join(dir, entry.name);
+    const rel = path.relative(root, abs).split(path.sep).join('/');
+
+    if (EXCLUDED_DIRS.has(entry.name)) continue;
+    if (ignoreMatcher(rel)) continue;
+
+    if (entry.isDirectory()) {
+      yield* walkDir(root, abs, ignoreMatcher);
+    } else if (entry.isFile()) {
+      const ext = path.extname(entry.name).toLowerCase();
+      if (!SCANNABLE_EXTENSIONS.has(ext)) continue;
+      yield abs;
+    }
+  }
+}

--- a/bump-doc-versions/products/scalardb.json
+++ b/bump-doc-versions/products/scalardb.json
@@ -1,0 +1,35 @@
+{
+  "product": "scalardb",
+  "envVarPrefixes": [
+    "SCALAR_DB_CLUSTER_VERSION",
+    "SCALAR_DB_VERSION"
+  ],
+  "mavenArtifacts": [
+    "scalardb",
+    "scalardb-cluster-java-client-sdk",
+    "scalardb-cluster-common",
+    "scalardb-cluster-rpc",
+    "scalardb-cluster-embedding-java-client-sdk",
+    "scalardb-sql",
+    "scalardb-sql-jdbc",
+    "scalardb-sql-spring-data"
+  ],
+  "mavenArtifactsRegex": [
+    "scalardb-analytics-spark-all-\\d+\\.\\d+_\\d+\\.\\d+"
+  ],
+  "ghcrImages": [
+    "scalardb-cluster-node-byol-premium",
+    "scalardb-cluster-node-byol-standard",
+    "scalardb-cluster-node-with-abac-byol-premium",
+    "scalardb-cluster-schema-loader",
+    "scalardb-cluster-sql-cli",
+    "scalardb-analytics-cli"
+  ],
+  "releaseRepos": [
+    "scalardb"
+  ],
+  "jarBases": [
+    "scalardb-cluster-schema-loader",
+    "scalardb-cluster-sql-cli"
+  ]
+}

--- a/bump-doc-versions/products/scalardl.json
+++ b/bump-doc-versions/products/scalardl.json
@@ -1,0 +1,20 @@
+{
+  "product": "scalardl",
+  "envVarPrefixes": [
+    "SCALAR_DL_VERSION",
+    "SCALAR_DL_AUDITOR_VERSION"
+  ],
+  "mavenArtifacts": [
+    "scalardl-java-client-sdk",
+    "scalardl-common"
+  ],
+  "mavenArtifactsRegex": [],
+  "ghcrImages": [
+    "scalardl-ledger",
+    "scalardl-auditor"
+  ],
+  "releaseRepos": [
+    "scalardl"
+  ],
+  "jarBases": []
+}

--- a/bump-doc-versions/sample-usage.yaml
+++ b/bump-doc-versions/sample-usage.yaml
@@ -1,0 +1,177 @@
+# Sample usage for bump-doc-versions.
+#
+# Two caller workflows per product. Copy each into the appropriate repo under
+# .github/workflows/, replacing <PRODUCT> with `scalardb` or `scalardl`.
+
+# ─── ①  Public repo:  docs-scalardb/.github/workflows/trigger-version-bump.yml ─
+# Fires on any push to `main` that touches `docusaurus.config.js`. Detects a
+# `className` diff, then:
+#   (a) dispatches into the internal repo for the authoritative bump PR, and
+#   (b) runs a safety-net bump against the public repo itself (idempotent —
+#       becomes a no-op if the internal sync PR lands first).
+
+name: 🔢 Trigger version bump on className change
+
+on:
+  push:
+    branches: [main]
+    paths: [docusaurus.config.js]
+  workflow_dispatch:
+    inputs:
+      minor:
+        description: 'Minor entry key (e.g. "3.17" or "current")'
+        required: true
+        type: string
+      to:
+        description: 'Target full version X.Y.Z'
+        required: true
+        type: string
+      from:
+        description: 'Optional source version X.Y.Z (auto-derived when omitted)'
+        required: false
+        type: string
+        default: ''
+
+permissions:
+  contents: read
+
+jobs:
+  detect:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    outputs:
+      bumps: ${{ steps.diff.outputs.bumps }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Checkout detect-classname-diff script
+        uses: actions/checkout@v4
+        with:
+          repository: josh-wong/actions
+          ref: main
+          sparse-checkout: bump-doc-versions
+          path: actions-tools
+
+      - name: Extract before/after docusaurus.config.js
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+          AFTER_SHA:  ${{ github.event.after }}
+        run: |
+          git show "$BEFORE_SHA:docusaurus.config.js" > /tmp/before.js 2>/dev/null || : > /tmp/before.js
+          git show "$AFTER_SHA:docusaurus.config.js"  > /tmp/after.js
+
+      - name: Detect className diffs
+        id: diff
+        run: |
+          bumps=$(node actions-tools/bump-doc-versions/detect-classname-diff.mjs \
+            --before /tmp/before.js \
+            --after  /tmp/after.js)
+          echo "bumps=$bumps" >> "$GITHUB_OUTPUT"
+          echo "Detected: $bumps"
+
+  dispatch-internal:
+    needs: detect
+    if: needs.detect.outputs.bumps != '' && needs.detect.outputs.bumps != '[]'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        bump: ${{ fromJson(needs.detect.outputs.bumps) }}
+    steps:
+      - name: Dispatch bump into docs-internal-<PRODUCT>
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.BUMP_DISPATCH_PAT }}
+          script: |
+            const bump = ${{ toJson(matrix.bump) }};
+            await github.rest.repos.createDispatchEvent({
+              owner: context.repo.owner,
+              repo:  'docs-internal-<PRODUCT>',
+              event_type: 'bump-patch',
+              client_payload: { product: '<PRODUCT>', ...bump },
+            });
+
+  safety-net-public:
+    needs: detect
+    if: needs.detect.outputs.bumps != '' && needs.detect.outputs.bumps != '[]'
+    strategy:
+      matrix:
+        bump: ${{ fromJson(needs.detect.outputs.bumps) }}
+    uses: josh-wong/actions/.github/workflows/bump-doc-versions-reusable.yaml@main
+    with:
+      product:     <PRODUCT>
+      repo:        public
+      minor:       ${{ matrix.bump.minor }}
+      from:        ${{ matrix.bump.from }}
+      to:          ${{ matrix.bump.to }}
+      base_branch: main
+      head_branch: bump/<PRODUCT>-${{ matrix.bump.to }}
+      pr_title:    "chore: bump ${{ matrix.bump.from }} → ${{ matrix.bump.to }} (safety net)"
+      pr_body_style: public-safety-net
+    secrets:
+      github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  manual:
+    if: github.event_name == 'workflow_dispatch'
+    uses: josh-wong/actions/.github/workflows/bump-doc-versions-reusable.yaml@main
+    with:
+      product:     <PRODUCT>
+      repo:        public
+      minor:       ${{ inputs.minor }}
+      from:        ${{ inputs.from }}
+      to:          ${{ inputs.to }}
+      base_branch: main
+      head_branch: bump/<PRODUCT>-${{ inputs.to }}
+      pr_title:    "chore: bump ${{ inputs.from }} → ${{ inputs.to }} (manual)"
+      pr_body_style: public-safety-net
+    secrets:
+      github_token: ${{ secrets.GITHUB_TOKEN }}
+
+---
+# ─── ②  Internal repo: docs-internal-scalardb/.github/workflows/bump-doc-versions.yml
+# Runs on repository_dispatch from the public repo, or on manual workflow_dispatch.
+# Targets the matching version branch and opens a PR against it.
+
+name: 🔢 Bump patch version in docs
+
+on:
+  repository_dispatch:
+    types: [bump-patch]
+  workflow_dispatch:
+    inputs:
+      minor:
+        description: 'Minor branch (e.g. "3.17")'
+        required: true
+        type: string
+      to:
+        description: 'Target full version X.Y.Z'
+        required: true
+        type: string
+      from:
+        description: 'Optional source version X.Y.Z'
+        required: false
+        type: string
+        default: ''
+      dry_run:
+        description: 'Report only; do not commit / push / open PR'
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  bump:
+    uses: josh-wong/actions/.github/workflows/bump-doc-versions-reusable.yaml@main
+    with:
+      product:     <PRODUCT>
+      repo:        internal
+      minor:       ${{ github.event.client_payload.minor || inputs.minor }}
+      to:          ${{ github.event.client_payload.to    || inputs.to }}
+      from:        ${{ github.event.client_payload.from  || inputs.from }}
+      base_branch: ${{ github.event.client_payload.minor || inputs.minor }}
+      head_branch: update-${{ github.event.client_payload.minor || inputs.minor }}-patch-version-to-${{ github.event.client_payload.to || inputs.to }}
+      pr_title: "[${{ github.event.client_payload.minor || inputs.minor }}] Change patch version from `${{ github.event.client_payload.from || inputs.from }}` to `${{ github.event.client_payload.to || inputs.to }}`"
+      pr_body_style: internal
+      dry_run: ${{ inputs.dry_run || false }}
+    secrets:
+      github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Adds the automated patch-version bumper for the ScalarDB and ScalarDL docs. Implements Phase 0 §6.1/§6.2 of the version-bump-automation design (the script + reusable workflow — callers in the docs repos come next).

- **[`bump-doc-versions/`](https://github.com/josh-wong/actions/tree/add-bump-doc-versions/bump-doc-versions)** — zero-dependency Node script (P1–P10 anchored patterns, per-minor scope guard, ignore markers, JSON report).
- **[`bump-doc-versions/detect-classname-diff.mjs`](https://github.com/josh-wong/actions/blob/add-bump-doc-versions/bump-doc-versions/detect-classname-diff.mjs)** — parses `className` diffs in `docusaurus.config.js` for the public-repo trigger workflow.
- **[`bump-doc-versions/build-pr-body.mjs`](https://github.com/josh-wong/actions/blob/add-bump-doc-versions/bump-doc-versions/build-pr-body.mjs)** — renders the PR body from the JSON report (internal / public-safety-net styles).
- **[`bump-doc-versions/products/{scalardb,scalardl}.json`](https://github.com/josh-wong/actions/tree/add-bump-doc-versions/bump-doc-versions/products)** — artifact allowlists.
- **[`.github/workflows/bump-doc-versions-reusable.yaml`](https://github.com/josh-wong/actions/blob/add-bump-doc-versions/.github/workflows/bump-doc-versions-reusable.yaml)** — reusable workflow invoked by callers in the docs repos.
- **[`bump-doc-versions/sample-usage.yaml`](https://github.com/josh-wong/actions/blob/add-bump-doc-versions/bump-doc-versions/sample-usage.yaml)** — reference caller workflows.

## Verification

Ran locally against `docs-internal-scalardb@3.17` (dry-run):

| Scenario | Result |
|---|---|
| `internal --minor 3.17 --from 3.17.2 --to 3.17.99` | 39 files, 139 replacements (P1=30 P2=24 P3=13 P4=16 P6=20 P7=34 P8=2), diffs verified clean |
| Auto-`--from` on a drifted tree (3.17.1 + 3.17.2 both present) | Correctly refused (exit 3) with actionable message |
| Idempotent re-run | Exit 2, no-op |
| Cross-minor safety (`--minor 3.16` on 3.17 tree) | 0 replacements |
| `public --minor 3.17` on `docs-scalardb@main` | Parsed `className: '3.17.3'`, scoped correctly |
| `public --minor current` | Parsed `current: { className: '3.18.0' }`, updated className in report |
| `detect-classname-diff` on simulated diffs | Correct output for normal / minor-spanning / no-op |

## Not in scope for this PR

- Caller workflows in `docs-scalardb` and `docs-internal-scalardb` — separate follow-up PRs.
- Consistency CI check (design §6.5) — separate follow-up.
- Unit tests (design §13.1) — separate follow-up.
- ScalarDL config is placeholder per design §4.2 (v1 expected to be no-op).

## Known small gaps (deferred deliberately)

- `unknownArtifactsSeen` report field is reserved but not populated yet (design §11 E7). Cheap to add once a real unknown-artifact case shows up.
- `P2` proximity is a fixed 6 lines. Worked on the current 3.17 tree; may need widening.
- `P10` gate is file-level per design §6.1.4 (which supersedes the tighter same-line wording in §4.1). Consequence: `docs/consensus-commit.mdx` and `docs/api-guide.mdx` — the two prose-only files called out by name — will not be updated automatically.