### PR TITLE
Clarify `from` / `to` input descriptions

### DIFF
--- a/.github/workflows/bump-doc-versions-reusable.yaml
+++ b/.github/workflows/bump-doc-versions-reusable.yaml
@@ -21,11 +21,11 @@ on:
         required: true
         type: string
       to:
-        description: 'Target full version X.Y.Z'
+        description: 'New patch version to bump to (e.g., "3.18.2"). This is the version the docs will now reference.'
         required: true
         type: string
       from:
-        description: 'Source version X.Y.Z. Optional — auto-derived from className (public) or the first anchored match (internal) when omitted.'
+        description: 'Current patch version to bump from (e.g., "3.18.1"). Optional: Auto-detected from `className` (in the docs site config) or the first anchored match (in this repo) when omitted.'
         required: false
         type: string
         default: ''

--- a/bump-doc-versions/README.md
+++ b/bump-doc-versions/README.md
@@ -45,8 +45,8 @@ node bump-doc-versions/bump-doc-versions.mjs \
 | `--product` | yes | `scalardb` or `scalardl`. Selects the product config file under `products/`. |
 | `--repo` | yes | `internal` or `public`. Selects the file-scope map (see below). |
 | `--minor` | yes | `3.17`, `3.18`, …, or `current` (only valid with `--repo public`). |
-| `--to` | yes | Target full version `X.Y.Z`. Must satisfy `X.Y === --minor` (or `X.Y === current-minor` when `--minor current`). |
-| `--from` | no | Source version. Auto-derived from `className` (public) or the first anchored match under `docs/en-us/**` (internal) when omitted. Errors out if the auto-derivation is ambiguous. |
+| `--to` | yes | New patch version to bump to (e.g., `3.18.2`). Must satisfy `X.Y === --minor` (or `X.Y === current-minor` when `--minor current`). |
+| `--from` | no | Current patch version to bump from (e.g., `3.18.1`). Auto-detected from `className` (in the docs site config) or the first anchored match under `docs/en-us/**` (in the internal repo) when omitted. Errors out if the auto-detection is ambiguous. |
 | `--root` | no | Root of the target repo. Defaults to `.`. |
 | `--dry-run` | no | Do not write files or update `className`. Report only. |
 | `--json-report <path>` | no | Write a machine-readable report to `<path>`. |
@@ -62,6 +62,11 @@ node bump-doc-versions/bump-doc-versions.mjs \
 | `1` | Unexpected error. |
 
 ### File-scope map
+
+`--repo` selects which side of the ScalarDB/ScalarDL docs pipeline the script is targeting:
+
+- **`internal`** — the source-of-truth repo (`docs-internal-scalardb`, `docs-internal-scalardl`). One branch per minor version (`3.14`, `3.15`, …, `3.18`). Both English and Japanese docs live side-by-side under `docs/en-us/**` and `docs/ja-jp/**` on the same branch. Bump PRs are opened against the version branch itself.
+- **`public`** — the Docusaurus docs-site repo (`docs-scalardb`, `docs-scalardl`). Single `main` branch containing every version. The `current` minor lives under `docs/**`; older minors live under `versioned_docs/version-<minor>/**`. Japanese translations are mirrored under `i18n/versioned_docs/ja-jp/**`. The `className` field in `docusaurus.config.js` is the source of truth for "current patch of each minor".
 
 | `--repo` | `--minor` | Scope walked |
 |---|---|---|

--- a/bump-doc-versions/sample-usage.yaml
+++ b/bump-doc-versions/sample-usage.yaml
@@ -19,15 +19,15 @@ on:
   workflow_dispatch:
     inputs:
       minor:
-        description: 'Minor entry key (e.g. "3.17" or "current")'
+        description: 'Minor version entry to bump (for example, "3.17", or "current" for whichever minor is currently labeled `current`)'
         required: true
         type: string
       to:
-        description: 'Target full version X.Y.Z'
+        description: 'New patch version to bump to (e.g., "3.18.2"). This is the version the docs will now reference.'
         required: true
         type: string
       from:
-        description: 'Optional source version X.Y.Z (auto-derived when omitted)'
+        description: 'Current patch version to bump from (e.g., "3.18.1"). Optional: Auto-detected from `className` (in the docs site config) or the first anchored match (in this repo) when omitted.'
         required: false
         type: string
         default: ''
@@ -141,15 +141,15 @@ on:
   workflow_dispatch:
     inputs:
       minor:
-        description: 'Minor branch (e.g. "3.17")'
+        description: 'Minor version branch to bump (for example, "3.17")'
         required: true
         type: string
       to:
-        description: 'Target full version X.Y.Z'
+        description: 'New patch version to bump to (e.g., "3.18.2"). This is the version the docs will now reference.'
         required: true
         type: string
       from:
-        description: 'Optional source version X.Y.Z'
+        description: 'Current patch version to bump from (e.g., "3.18.1"). Optional: Auto-detected from `className` (in the docs site config) or the first anchored match (in this repo) when omitted.'
         required: false
         type: string
         default: ''


### PR DESCRIPTION
Follow-up to #104. Rewrites the workflow input descriptions for `from` and `to` after the previous "Target full version X.Y.Z" / "Optional source version X.Y.Z" wording was flagged as confusing (which one was 'the new version', which was 'the current version'?).

## New wording

**`to` (required):** _The new patch version to bump to (for example, "3.17.4"). This is the version the docs will now reference._

**`from` (optional):** _The current patch version to bump from (for example, "3.17.3"). Optional — auto-detected from `className` (public) or the first anchored match (internal) when omitted._

## Files touched

- `.github/workflows/bump-doc-versions-reusable.yaml` — `workflow_call` inputs (reusable workflow — mostly for developers reading the source, not shown in the workflow_dispatch UI).
- `bump-doc-versions/sample-usage.yaml` — both the public and internal caller `workflow_dispatch` inputs, which _are_ shown in the workflow_dispatch UI form.
- `bump-doc-versions/README.md` — flag table for CLI usage.

## Companion pushes

Same wording will be pushed to the two open docs-repo caller PRs:

- `josh-wong/docs-internal-scalardb#1` (`add-bump-doc-versions-caller`)
- `josh-wong/docs-scalardb#1` (`add-trigger-version-bump`)