### PR TITLE
Internal-caller cleanup: drop `minor` input; rename reserved secret

### DIFF
--- a/.github/workflows/bump-doc-versions-reusable.yaml
+++ b/.github/workflows/bump-doc-versions-reusable.yaml
@@ -52,8 +52,8 @@ on:
         type: boolean
         default: false
     secrets:
-      github_token:
-        description: 'Token with `contents: write` and `pull-requests: write` on the caller repo. GITHUB_TOKEN works for same-repo operations.'
+      token:
+        description: 'Token with `contents: write` and `pull-requests: write` on the caller repo. The built-in `GITHUB_TOKEN` works for same-repo operations.'
         required: true
 
 jobs:
@@ -90,7 +90,7 @@ jobs:
         with:
           ref: ${{ inputs.base_branch }}
           fetch-depth: 0
-          token: ${{ secrets.github_token }}
+          token: ${{ secrets.token }}
           path: repo
 
       - name: Set up Node.js
@@ -161,7 +161,7 @@ jobs:
         if: steps.bump.outputs.exit_code == '0' && !inputs.dry_run
         working-directory: repo
         env:
-          GH_TOKEN:    ${{ secrets.github_token }}
+          GH_TOKEN:    ${{ secrets.token }}
           BASE_BRANCH: ${{ inputs.base_branch }}
           HEAD_BRANCH: ${{ inputs.head_branch }}
           PR_TITLE:    ${{ inputs.pr_title }}

--- a/bump-doc-versions/README.md
+++ b/bump-doc-versions/README.md
@@ -113,17 +113,17 @@ The reusable workflow lives at [`.github/workflows/bump-doc-versions-reusable.ya
 
 See [`sample-usage.yaml`](./sample-usage.yaml) for ready-to-copy caller workflows:
 
-- **Internal repo caller** — `docs-internal-scalardb/.github/workflows/bump-doc-versions.yml`. Accepts a `repository_dispatch` from the public repo, or a manual `workflow_dispatch`, and runs the reusable workflow against the matching version branch.
+- **Internal repo caller** — `docs-internal-scalardb/.github/workflows/bump-doc-versions.yml`. Accepts a `repository_dispatch` from the public repo, or a manual `workflow_dispatch`, and runs the reusable workflow against the matching version branch. The target minor is derived from `github.event.client_payload.minor` (for the automated flow) or `github.ref_name` (for manual dispatch — whatever branch you select in the **"Use workflow from"** dropdown). For the manual path to work, this file must be present on every active version branch (`3.14`, `3.15`, …, `3.18`) in addition to `main`.
 - **Public repo caller** — `docs-scalardb/.github/workflows/trigger-version-bump.yml`. Detects a `className` change in `docusaurus.config.js` on push to `main`, extracts `(minor, from, to)`, `repository_dispatch`es into the internal repo, and runs a safety-net bump on the public repo itself.
 
 ### Tokens
 
-The reusable workflow accepts one secret, `github_token`, with the following required permissions on the caller repo:
+The reusable workflow accepts one secret, `token`, with the following required permissions on the caller repo:
 
 - `contents: write` — to push the bump commit.
 - `pull-requests: write` — to open or update the PR.
 
-For **same-repo operations** (the internal caller pushing a bump PR to its own repo), the built-in `GITHUB_TOKEN` is sufficient — pass it via `secrets: inherit` or `github_token: ${{ secrets.GITHUB_TOKEN }}`.
+For **same-repo operations** (the internal caller pushing a bump PR to its own repo), the built-in `GITHUB_TOKEN` is sufficient — pass it via `secrets: inherit` or `token: ${{ secrets.GITHUB_TOKEN }}`.
 
 For the **cross-repo `repository_dispatch`** in the public-repo caller, a personal access token (or GitHub App installation token) with `contents: write` on the target internal repo is required. Store it as `BUMP_DISPATCH_PAT` in the public repo's secrets. See `sample-usage.yaml` for the exact usage.
 

--- a/bump-doc-versions/sample-usage.yaml
+++ b/bump-doc-versions/sample-usage.yaml
@@ -110,7 +110,7 @@ jobs:
       pr_title:    "chore: bump ${{ matrix.bump.from }} → ${{ matrix.bump.to }} (safety net)"
       pr_body_style: public-safety-net
     secrets:
-      github_token: ${{ secrets.GITHUB_TOKEN }}
+      token: ${{ secrets.GITHUB_TOKEN }}
 
   manual:
     if: github.event_name == 'workflow_dispatch'
@@ -126,12 +126,15 @@ jobs:
       pr_title:    "chore: bump ${{ inputs.from }} → ${{ inputs.to }} (manual)"
       pr_body_style: public-safety-net
     secrets:
-      github_token: ${{ secrets.GITHUB_TOKEN }}
+      token: ${{ secrets.GITHUB_TOKEN }}
 
 ---
-# ─── ②  Internal repo: docs-internal-scalardb/.github/workflows/bump-doc-versions.yml
-# Runs on repository_dispatch from the public repo, or on manual workflow_dispatch.
-# Targets the matching version branch and opens a PR against it.
+# ─── ②  Internal repo: docs-internal-<PRODUCT>/.github/workflows/bump-doc-versions.yml
+# Runs on repository_dispatch from the public repo, or on manual
+# workflow_dispatch. Targets the matching version branch and opens a PR
+# against it. For workflow_dispatch to work from a version branch, this
+# file must exist on every active version branch (e.g., 3.14–3.18) — the
+# 'Use workflow from' dropdown then supplies the minor via github.ref_name.
 
 name: 🔢 Bump patch version in docs
 
@@ -140,10 +143,6 @@ on:
     types: [bump-patch]
   workflow_dispatch:
     inputs:
-      minor:
-        description: 'Minor version branch to bump (for example, "3.17")'
-        required: true
-        type: string
       to:
         description: 'New patch version to bump to (e.g., "3.18.2"). This is the version the docs will now reference.'
         required: true
@@ -165,13 +164,13 @@ jobs:
     with:
       product:     <PRODUCT>
       repo:        internal
-      minor:       ${{ github.event.client_payload.minor || inputs.minor }}
+      minor:       ${{ github.event.client_payload.minor || github.ref_name }}
       to:          ${{ github.event.client_payload.to    || inputs.to }}
       from:        ${{ github.event.client_payload.from  || inputs.from }}
-      base_branch: ${{ github.event.client_payload.minor || inputs.minor }}
-      head_branch: update-${{ github.event.client_payload.minor || inputs.minor }}-patch-version-to-${{ github.event.client_payload.to || inputs.to }}
-      pr_title: "[${{ github.event.client_payload.minor || inputs.minor }}] Change patch version from `${{ github.event.client_payload.from || inputs.from }}` to `${{ github.event.client_payload.to || inputs.to }}`"
+      base_branch: ${{ github.event.client_payload.minor || github.ref_name }}
+      head_branch: update-${{ github.event.client_payload.minor || github.ref_name }}-patch-version-to-${{ github.event.client_payload.to || inputs.to }}
+      pr_title: "[${{ github.event.client_payload.minor || github.ref_name }}] Change patch version from `${{ github.event.client_payload.from || inputs.from }}` to `${{ github.event.client_payload.to || inputs.to }}`"
       pr_body_style: internal
       dry_run: ${{ inputs.dry_run || false }}
     secrets:
-      github_token: ${{ secrets.GITHUB_TOKEN }}
+      token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Two related caller-side cleanups for the internal-caller pattern.

## 🔧 Fix: rename the `workflow_call` secret from `github_token` to `token`

GitHub refuses `github_token` as a `workflow_call` secret name:

> `secret name \`github_token\` within \`workflow_call\` can not be used since it would collide with system reserved name`

This surfaced as [an invalid-workflow-file annotation on the last push](https://github.com/josh-wong/actions/actions/runs/29564681305). Any actual bump run would have failed the same way. Renamed to `token`:

```yaml
# In the reusable workflow (this repo)
secrets:
  token:
    description: 'Token with contents+PRs write on the caller repo'
    required: true

# In callers (docs repos)
secrets:
  token: ${{ secrets.GITHUB_TOKEN }}
```

## ✨ Cleanup: drop `minor` input, use `github.ref_name`

Removes the redundant `minor` `workflow_dispatch` input from the internal-caller template. The target minor now comes from:

- `github.event.client_payload.minor` — for the automated `repository_dispatch` flow.
- `github.ref_name` — for manual `workflow_dispatch` (whatever branch is selected in the **"Use workflow from"** dropdown).

Previously the template asked users to both select a branch from the dropdown AND retype it in a `minor` input field. The dropdown is now the single source of truth.

## Files changed

- **[`.github/workflows/bump-doc-versions-reusable.yaml`](https://github.com/josh-wong/actions/blob/internal-caller-use-ref-name/.github/workflows/bump-doc-versions-reusable.yaml)** — rename `github_token` → `token` (declaration + 2 usages).
- **[`bump-doc-versions/sample-usage.yaml`](https://github.com/josh-wong/actions/blob/internal-caller-use-ref-name/bump-doc-versions/sample-usage.yaml)** — both caller templates:
  - Internal caller (block ②): drops `minor` input, wires `minor` / `base_branch` / `head_branch` / `pr_title` through `\${{ github.event.client_payload.minor || github.ref_name }}`, header comment flags the cherry-pick-to-version-branches requirement.
  - All three caller blocks pass the token under the new name.
- **[`bump-doc-versions/README.md`](https://github.com/josh-wong/actions/blob/internal-caller-use-ref-name/bump-doc-versions/README.md)** — 'Internal repo caller' bullet explains the `github.ref_name` derivation; token references renamed.

## Follow-up consumer PRs required

Both changes are **breaking** for existing callers in the docs repos. After this merges I'll open:

- `josh-wong/docs-internal-scalardb` — rename `github_token` → `token` in [`bump-doc-versions.yml`](https://github.com/josh-wong/docs-internal-scalardb/blob/main/.github/workflows/bump-doc-versions.yml). (The `minor`-input refactor is already in flight in [PR #3](https://github.com/josh-wong/docs-internal-scalardb/pull/3), which needs a rebase to also carry the rename.)
- `josh-wong/docs-scalardb` — rename `github_token` → `token` in [`trigger-version-bump.yml`](https://github.com/josh-wong/docs-scalardb/blob/main/.github/workflows/trigger-version-bump.yml) (3 usages).

## Not touched

- **Reusable-workflow `minor` input** — still there on the `workflow_call` interface (callers compute it).
- **Public-caller template (block ① in `sample-usage.yaml`)** — `minor` input stays because `docs-scalardb` has a single `main` branch.