### PR TITLE
Grant caller-level permissions required by the reusable workflow

### DIFF
--- a/bump-doc-versions/sample-usage.yaml
+++ b/bump-doc-versions/sample-usage.yaml
@@ -33,7 +33,8 @@ on:
         default: ''
 
 permissions:
-  contents: read
+  contents: write
+  pull-requests: write
 
 jobs:
   detect:
@@ -157,6 +158,10 @@ on:
         required: false
         type: boolean
         default: false
+
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
   bump:


### PR DESCRIPTION
Fixes the [`Invalid workflow file`](https://github.com/josh-wong/docs-internal-scalardb/actions/runs/29565562431/workflow) error that appeared once callers actually tried to invoke the reusable workflow:

> Error calling workflow 'josh-wong/actions/.github/workflows/bump-doc-versions-reusable.yaml@main'. The nested job 'bump' is requesting 'contents: write, pull-requests: write', but is only allowed 'contents: read, pull-requests: none'.

## Root cause

The reusable workflow (`.github/workflows/bump-doc-versions-reusable.yaml`) declares job-level `permissions: contents: write, pull-requests: write` because it pushes a commit and opens a PR on the caller repo. A called workflow can only receive permissions the caller has granted, so the caller must declare at least those at the workflow level.

Under GitHub Actions' default `permissions` (repo setting "Read repository contents and packages permissions"), callers get `contents: read, pull-requests: none` — not enough.

## Changes

- **[`bump-doc-versions/sample-usage.yaml`](https://github.com/josh-wong/actions/blob/fix-caller-permissions/bump-doc-versions/sample-usage.yaml)**:
  - **Internal-caller template (block ②)** — adds a workflow-level `permissions:` block granting `contents: write` and `pull-requests: write`.
  - **Public-caller template (block ①)** — upgrades the existing `contents: read` to also include `contents: write` and `pull-requests: write` for the `safety-net-public` reusable-workflow job. The `detect` job has no local override, so it also gets write — harmless (it only reads git). The `dispatch-internal` job uses `BUMP_DISPATCH_PAT` and is unaffected by the default-token permissions.

## Not touched

- **Reusable workflow (`.github/workflows/bump-doc-versions-reusable.yaml`)** — its own job-level permissions request stays. The fix is entirely on the caller side.

## Follow-up consumer PRs required

Both changes are needed in the concrete callers to unblock end-to-end testing:

- `josh-wong/docs-internal-scalardb` — add `permissions:` block to `.github/workflows/bump-doc-versions.yml` on `main` + backport to `3.14`, `3.15`, `3.16`, `3.17`, `3.18`.
- `josh-wong/docs-scalardb` — upgrade `.github/workflows/trigger-version-bump.yml` `permissions:` block.