### PR TITLE
Fix reusable-workflow script checkout

### DIFF
--- a/.github/workflows/bump-doc-versions-reusable.yaml
+++ b/.github/workflows/bump-doc-versions-reusable.yaml
@@ -63,25 +63,16 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      # Derive the actions repo + ref from `github.workflow_ref` so this same
-      # workflow works whether the caller pins `@main`, `@v1`, or a SHA.
-      - name: Resolve actions repo & ref
-        id: refs
-        env:
-          WFREF: ${{ github.workflow_ref }}
-        run: |
-          # WFREF looks like: owner/repo/.github/workflows/name.yaml@refs/heads/main
-          repo="${WFREF%%/.github/*}"
-          ref="${WFREF##*@}"
-          echo "repo=$repo" >> "$GITHUB_OUTPUT"
-          echo "ref=$ref"   >> "$GITHUB_OUTPUT"
-          echo "Using script source: $repo @ $ref"
-
       - name: Checkout bump-doc-versions script
+        # Pins to the exact commit of the reusable workflow that's running,
+        # so the script version matches the workflow version. github.job_workflow_sha
+        # is set specifically for reusable-workflow jobs and points at the
+        # commit of the reusable workflow file — see
+        # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#github-context
         uses: actions/checkout@v4
         with:
-          repository: ${{ steps.refs.outputs.repo }}
-          ref: ${{ steps.refs.outputs.ref }}
+          repository: josh-wong/actions
+          ref: ${{ github.job_workflow_sha }}
           sparse-checkout: bump-doc-versions
           path: actions-tools
 


### PR DESCRIPTION
## The bug

Your dry-run dispatch of `bump-doc-versions` from `docs-internal-scalardb@3.17` failed with:

    Error: Cannot find module '.../actions-tools/bump-doc-versions/bump-doc-versions.mjs'

Root cause: the "Resolve actions repo & ref" step used `github.workflow_ref`, which resolves to the **root/calling workflow**, not the reusable workflow itself. The log showed:

    Using script source: josh-wong/docs-internal-scalardb @ refs/heads/3.17

That's the caller — which of course does not contain the `bump-doc-versions/` directory the script lives in.

## The fix

- Delete the "Resolve actions repo & ref" step.
- Hardcode `repository: josh-wong/actions` (this reusable workflow lives here).
- Use [`ref: ${{ github.job_workflow_sha }}`](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#github-context) — this context variable is set specifically for reusable-workflow jobs and points at the commit SHA of the reusable workflow file being executed. Callers can pin `@main` / `@v1` / `@<sha>` freely; the script always comes from the matching commit.

## Migration note

When this ever moves to `scalar-labs/actions`, the `repository:` line will need to change accordingly. Two lines to update; add a TODO comment if you want a permanent reminder.

## Fixed by this PR

- [`.github/workflows/bump-doc-versions-reusable.yaml`](https://github.com/josh-wong/actions/blob/fix-checkout-script-source/.github/workflows/bump-doc-versions-reusable.yaml) — 7 insertions, 16 deletions.