### PR TITLE
Support minor and major bumps via manual workflow_dispatch

### DIFF
--- a/bump-doc-versions/README.md
+++ b/bump-doc-versions/README.md
@@ -44,9 +44,9 @@ node bump-doc-versions/bump-doc-versions.mjs \
 |---|---|---|
 | `--product` | yes | `scalardb` or `scalardl`. Selects the product config file under `products/`. |
 | `--repo` | yes | `internal` or `public`. Selects the file-scope map (see below). |
-| `--minor` | yes | `3.17`, `3.18`, …, or `current` (only valid with `--repo public`). |
-| `--to` | yes | New patch version to bump to (e.g., `3.18.2`). Must satisfy `X.Y === --minor` (or `X.Y === current-minor` when `--minor current`). |
-| `--from` | no | Current patch version to bump from (e.g., `3.18.1`). Auto-detected from `className` (in the docs site config) or the first anchored match under `docs/en-us/**` (in the internal repo) when omitted. Errors out if the auto-detection is ambiguous. |
+| `--minor` | yes | Scope selector. On `--repo public`: `X.Y` (e.g., `3.17`) or `current`. On `--repo internal`: any string — typically the branch name (`3.17`, `main`, `3`). Used as a label on internal (PR title / report); the actual match filter is driven by `--from`. |
+| `--to` | yes | New version to bump to (e.g., `3.17.4` for a patch, `3.19.0` for a minor, `4.0.0` for a major). Must satisfy `X.Y === --minor` on `--repo public`; may differ on `--repo internal` (cross-minor bumps are allowed there). |
+| `--from` | no | Current version to bump from (e.g., `3.17.3`). Auto-detected from `className` (public repo) or the first anchored match under `docs/en-us/**` (internal repo, `--minor` in `X.Y` form) when omitted. **Required for cross-minor bumps** on internal. Errors out if the auto-detection is ambiguous. |
 | `--root` | no | Root of the target repo. Defaults to `.`. |
 | `--dry-run` | no | Do not write files or update `className`. Report only. |
 | `--json-report <path>` | no | Write a machine-readable report to `<path>`. |
@@ -91,7 +91,9 @@ All ten patterns are enumerated in the design doc. In short:
 | `P9` | Analytics Spark trailing version | `com.scalar-labs:scalardb-analytics-spark-all-3.5_2.12:3.17.2` (via `mavenArtifactsRegex`) |
 | `P10` | Bare `X.Y.Z` in prose | `"ScalarDB 3.16.5, 3.17.3, or 3.18.0"` — gated on the file having at least one P1–P9 same-minor match |
 
-**Scope guard:** for every pattern except P10, only occurrences where `X.Y === --minor` are rewritten. On the `3.17` branch, `3.16.5` and `3.18.0` in a prose line are left alone.
+**Scope guard:** for every pattern except P10, only occurrences where `X.Y === --from`'s X.Y are rewritten (i.e., the source minor). For a same-minor patch bump on the `3.17` branch, `3.16.5` and `3.18.0` in a prose line are left alone. For a cross-minor bump (e.g., `--from 3.18.5 --to 3.19.0` on `main`), all `3.18.X` references get rewritten to `3.19.0`, while `3.17.X` and `3.19.X` mentions are left alone.
+
+**Cross-minor bumps** (minor or major): the script logs a `⚠️ cross-minor bump` warning and the generated PR body includes the same warning banner. `--from` must be provided explicitly — auto-detection only supports same-minor bumps.
 
 ### Ignore markers
 
@@ -113,7 +115,7 @@ The reusable workflow lives at [`.github/workflows/bump-doc-versions-reusable.ya
 
 See [`sample-usage.yaml`](./sample-usage.yaml) for ready-to-copy caller workflows:
 
-- **Internal repo caller** — `docs-internal-scalardb/.github/workflows/bump-doc-versions.yml`. Accepts a `repository_dispatch` from the public repo, or a manual `workflow_dispatch`, and runs the reusable workflow against the matching version branch. The target minor is derived from `github.event.client_payload.minor` (for the automated flow) or `github.ref_name` (for manual dispatch — whatever branch you select in the **"Use workflow from"** dropdown). For the manual path to work, this file must be present on every active version branch (`3.14`, `3.15`, …, `3.18`) in addition to `main`.
+- **Internal repo caller** — `docs-internal-scalardb/.github/workflows/bump-doc-versions.yml`. Accepts a `repository_dispatch` from the public repo (patch bumps only) or a manual `workflow_dispatch` (patch, minor, or major bumps). The target minor is derived from `github.event.client_payload.minor` (automated flow), an optional `minor` input (explicit override), or `github.ref_name` (branch selected in the **"Use workflow from"** dropdown), in that order. For the manual path to work from a version branch, this file must be present on every active version branch (`3.14`, `3.15`, …, `3.18`) in addition to `main` (and `3` if you use that for the next-minor line).
 - **Public repo caller** — `docs-scalardb/.github/workflows/trigger-version-bump.yml`. Detects a `className` change in `docusaurus.config.js` on push to `main`, extracts `(minor, from, to)`, `repository_dispatch`es into the internal repo, and runs a safety-net bump on the public repo itself.
 
 ### Tokens

--- a/bump-doc-versions/build-pr-body.mjs
+++ b/bump-doc-versions/build-pr-body.mjs
@@ -27,8 +27,13 @@ async function main() {
   await fs.writeFile(values.out, body, 'utf8');
 }
 
+function crossMinorBanner(r) {
+  if (!r.crossMinor) return '';
+  return `> ⚠️ **Cross-minor bump.** This PR rewrites all \`${r.sourceMinor}.X\` references in scope to \`${r.to}\` (source minor \`${r.sourceMinor}\` → target minor \`${r.targetMinor}\`). Please verify the diff carefully — the scope-guard was relaxed to allow this cross-minor rewrite.\n\n`;
+}
+
 function renderInternal(r) {
-  return `## Description
+  return `${crossMinorBanner(r)}## Description
 
 This PR updates documentation references throughout the ${r.product === 'scalardb' ? 'ScalarDB' : 'ScalarDL'} \`${r.minor}\` docs to use version \`${r.to}\` instead of \`${r.from}\`. The changes ensure that all code snippets, dependency instructions, download links, Docker image tags, and Javadoc URLs point to the latest release.
 
@@ -38,7 +43,7 @@ N/A
 
 ## Changes made
 
-- Changed the patch version to the latest version (\`${r.from}\` → \`${r.to}\`).
+- Updated version references (\`${r.from}\` → \`${r.to}\`).
 
 ## Checklist
 
@@ -50,20 +55,20 @@ N/A
 
 ## Additional notes
 
-Opened automatically by [\`bump-doc-versions\`](https://github.com/josh-wong/actions/tree/main/bump-doc-versions) in response to a \`className\` update on \`main\` of the public docs repo.
+Opened automatically by [\`bump-doc-versions\`](https://github.com/josh-wong/actions/tree/main/bump-doc-versions)${r.crossMinor ? ' via a manual `workflow_dispatch` (cross-minor bump)' : ' in response to a `className` update on `main` of the public docs repo'}.
 
 ${renderVerification(r)}
 `;
 }
 
 function renderSafetyNet(r) {
-  return `## Description
+  return `${crossMinorBanner(r)}## Description
 
-Safety-net patch-version bump opened automatically after a \`className\` change on \`main\`. This covers files in the public repo that don't sync from the internal repo. If the internal-repo sync PR arrives first, this bot will notice the no-op and skip re-opening.
+Safety-net version bump opened automatically after a \`className\` change on \`main\`. This covers files in the public repo that don't sync from the internal repo. If the internal-repo sync PR arrives first, this bot will notice the no-op and skip re-opening.
 
 ## Changes made
 
-- Changed the patch version to the latest version (\`${r.from}\` → \`${r.to}\`).
+- Updated version references (\`${r.from}\` → \`${r.to}\`).
 
 ${renderVerification(r)}
 `;
@@ -75,7 +80,12 @@ function renderVerification(r) {
   lines.push('');
   lines.push(`- **Product:** \`${r.product}\``);
   lines.push(`- **Repo scope:** \`${r.repo}\``);
-  lines.push(`- **Minor:** \`${r.minor}\`${r.minorRequested && r.minorRequested !== r.minor ? ` (requested: \`${r.minorRequested}\`)` : ''}`);
+  lines.push(`- **Minor label:** \`${r.minor}\`${r.minorRequested && r.minorRequested !== r.minor ? ` (requested: \`${r.minorRequested}\`)` : ''}`);
+  if (r.crossMinor) {
+    lines.push(`- **Bump kind:** cross-minor (source \`${r.sourceMinor}\` → target \`${r.targetMinor}\`)`);
+  } else if (r.sourceMinor) {
+    lines.push(`- **Bump kind:** same-minor (\`${r.sourceMinor}\`)`);
+  }
   lines.push(`- **From → To:** \`${r.from}\` → \`${r.to}\``);
   lines.push(`- **Dry run:** ${r.dryRun ? 'yes' : 'no'}`);
   lines.push(`- **Files changed:** ${r.totals.files}`);

--- a/bump-doc-versions/bump-doc-versions.mjs
+++ b/bump-doc-versions/bump-doc-versions.mjs
@@ -64,7 +64,17 @@ async function main() {
   const cfgPath = path.join(__dirname, 'products', `${values.product}.json`);
   const config = JSON.parse(await fs.readFile(cfgPath, 'utf8'));
 
+  const toMinor = `${toParts[0]}.${toParts[1]}`;
+
   // ── Resolve effectiveMinor (handles --minor current) ──────────────────────
+  //
+  // `--minor` semantics differ by --repo:
+  //   - public: must be an existing versioned entry ('X.Y') or 'current'.
+  //     Public bumps are always same-minor (patch bumps against a fixed
+  //     versioned_docs/version-X.Y/ folder or the current-minor docs).
+  //   - internal: any string is accepted (branch name, e.g., '3.17', 'main',
+  //     or '3'). Used only as a label for the PR title / report. The actual
+  //     match-filter for rewrites is driven by --from's X.Y (see below).
   let effectiveMinor = values.minor;
   let publicCurrentMinor = null;
   let isCurrent = false;
@@ -82,18 +92,23 @@ async function main() {
       effectiveMinor = publicCurrentMinor;
       isCurrent = true;
     } else {
+      if (!/^\d+\.\d+$/.test(values.minor)) {
+        fail(3, `--minor for --repo public must be 'X.Y' or 'current' (got: ${values.minor})`);
+      }
       isCurrent = values.minor === publicCurrentMinor;
+    }
+    // Public bumps are always same-minor — enforce.
+    if (toMinor !== effectiveMinor) {
+      fail(3, `--to ${values.to} has minor ${toMinor}, does not match --minor ${effectiveMinor} (public repo requires same-minor bumps)`);
     }
   } else if (values.minor === 'current') {
     fail(3, `--minor current is only valid with --repo public`);
   }
 
-  const toMinor = `${toParts[0]}.${toParts[1]}`;
-  if (toMinor !== effectiveMinor) {
-    fail(3, `--to ${values.to} has minor ${toMinor}, does not match --minor ${effectiveMinor}`);
-  }
-
   // ── Derive --from if omitted ──────────────────────────────────────────────
+  //
+  // Auto-derivation only makes sense for same-minor bumps. For cross-minor
+  // (minor / major) bumps on internal, --from must be provided explicitly.
   let fromVer = values.from;
   if (!fromVer) {
     if (values.repo === 'public') {
@@ -102,6 +117,12 @@ async function main() {
         fail(3, `Could not derive --from from className for entry ${values.minor}`);
       }
     } else {
+      // On internal, auto-derivation requires --minor to be X.Y form
+      // (so we know what X.Y to scan for). For branch names like 'main' or
+      // '3', the caller must pass --from.
+      if (!/^\d+\.\d+$/.test(values.minor)) {
+        fail(3, `--from is required when --minor is not in X.Y form (got --minor '${values.minor}'). Auto-derivation only supports same-minor bumps on X.Y branches; for cross-minor (minor/major) bumps, pass --from explicitly.`);
+      }
       const derived = await deriveFromInternal(root, effectiveMinor, config);
       if (derived.error) fail(3, derived.error);
       fromVer = derived.version;
@@ -117,13 +138,23 @@ async function main() {
   }
 
   const fromParts = fromVer.split('.');
-  if (fromParts.length !== 3 || `${fromParts[0]}.${fromParts[1]}` !== effectiveMinor) {
-    fail(3, `--from ${fromVer} does not belong to minor ${effectiveMinor}`);
+  if (fromParts.length !== 3 || !fromParts.every((p) => /^\d+$/.test(p))) {
+    fail(3, `--from must be X.Y.Z (got: ${fromVer})`);
   }
+  const sourceMinor = `${fromParts[0]}.${fromParts[1]}`;
+
+  // Cross-minor detection (only meaningful on internal, since public enforces same-minor above).
+  const isCrossMinor = sourceMinor !== toMinor;
+
   if (fromVer === values.to) {
     console.log(`--from and --to are both ${fromVer}; nothing to do.`);
     await maybeWriteEmptyReport(values, effectiveMinor, fromVer);
     process.exit(2);
+  }
+
+  if (isCrossMinor) {
+    console.log(`⚠️  Cross-minor bump: ${sourceMinor} → ${toMinor} (${fromVer} → ${values.to})`);
+    console.log(`   The scope-guard filter uses source minor ${sourceMinor}; ALL ${sourceMinor}.X references in scope will be rewritten. Verify the diff carefully.`);
   }
 
   // ── Walk file scope ───────────────────────────────────────────────────────
@@ -135,6 +166,9 @@ async function main() {
     repo: values.repo,
     minor: effectiveMinor,
     minorRequested: values.minor,
+    sourceMinor,
+    targetMinor: toMinor,
+    crossMinor: isCrossMinor,
     from: fromVer,
     to: values.to,
     dryRun: values['dry-run'],
@@ -149,7 +183,9 @@ async function main() {
 
   for await (const abs of walkScope(root, scopePaths, ignoreMatcher)) {
     const content = await fs.readFile(abs, 'utf8');
-    const { matches, skipped } = matchFile(content, effectiveMinor, config);
+    // Match filter is driven by the source minor (from --from's X.Y),
+    // not by --minor. Same value for patch bumps; differs for minor/major bumps.
+    const { matches, skipped } = matchFile(content, sourceMinor, config);
     const rel = path.relative(root, abs).split(path.sep).join('/');
 
     if (skipped) {
@@ -250,11 +286,18 @@ async function deriveFromInternal(root, minor, config) {
 
 async function maybeWriteEmptyReport(values, minor, fromVer) {
   if (!values['json-report']) return;
+  const fromParts = (fromVer || '').split('.');
+  const toParts = (values.to || '').split('.');
+  const sourceMinor = fromParts.length >= 2 ? `${fromParts[0]}.${fromParts[1]}` : null;
+  const targetMinor = toParts.length >= 2 ? `${toParts[0]}.${toParts[1]}` : null;
   const empty = {
     product: values.product,
     repo: values.repo,
     minor,
     minorRequested: values.minor,
+    sourceMinor,
+    targetMinor,
+    crossMinor: sourceMinor !== null && targetMinor !== null && sourceMinor !== targetMinor,
     from: fromVer,
     to: values.to,
     dryRun: values['dry-run'],

--- a/bump-doc-versions/sample-usage.yaml
+++ b/bump-doc-versions/sample-usage.yaml
@@ -131,13 +131,17 @@ jobs:
 
 ---
 # ─── ②  Internal repo: docs-internal-<PRODUCT>/.github/workflows/bump-doc-versions.yml
-# Runs on repository_dispatch from the public repo, or on manual
-# workflow_dispatch. Targets the matching version branch and opens a PR
-# against it. For workflow_dispatch to work from a version branch, this
-# file must exist on every active version branch (e.g., 3.14–3.18) — the
-# 'Use workflow from' dropdown then supplies the minor via github.ref_name.
+# Runs on repository_dispatch from the public repo (patch bumps only),
+# or on manual workflow_dispatch (patch, minor, and major bumps).
+#
+# For workflow_dispatch to work from a version branch, this file must
+# exist on every active version branch (e.g., 3.14–3.18) — the "Use
+# workflow from" dropdown then supplies the minor via github.ref_name.
+# For minor / major bumps (which have no version branch yet), dispatch
+# from `main` (major) or `3` (next minor) and provide the optional
+# `minor` input to label the PR (e.g., "3.19" or "4.0").
 
-name: 🔢 Bump patch version in docs
+name: 🔢 Bump version references in docs
 
 on:
   repository_dispatch:
@@ -145,11 +149,16 @@ on:
   workflow_dispatch:
     inputs:
       to:
-        description: 'New patch version to bump to (e.g., "3.18.2"). This is the version the docs will now reference.'
+        description: 'New version to bump to (e.g., "3.17.4" for a patch, "3.19.0" for a minor, "4.0.0" for a major)'
         required: true
         type: string
       from:
-        description: 'Current patch version to bump from (e.g., "3.18.1"). Optional: Auto-detected from `className` (in the docs site config) or the first anchored match (in this repo) when omitted.'
+        description: 'Current version to bump from (e.g., "3.17.3"). Optional for patch bumps (auto-detected from an anchored match in this repo); required for minor / major bumps.'
+        required: false
+        type: string
+        default: ''
+      minor:
+        description: 'Target minor label for the PR title (e.g., "3.19" or "4.0"). Optional — defaults to the branch selected in "Use workflow from" when that branch is X.Y form.'
         required: false
         type: string
         default: ''
@@ -164,17 +173,36 @@ permissions:
   pull-requests: write
 
 jobs:
+  guard:
+    # Reject workflow_dispatch runs from a non-X.Y branch (e.g. `main`, `3`)
+    # unless an explicit `minor` label override is provided. Skipped on
+    # repository_dispatch (client_payload always carries `minor`).
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate dispatch context
+        env:
+          MINOR_INPUT: ${{ inputs.minor }}
+        run: |
+          if [ -n "$MINOR_INPUT" ]; then exit 0; fi
+          if ! [[ "${GITHUB_REF_NAME}" =~ ^[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Dispatched from '${GITHUB_REF_NAME}', which isn't a version branch (X.Y). Either pick a version branch from the 'Use workflow from' dropdown, or provide the 'minor' input as an explicit target-minor label (e.g., '3.19' or '4.0')."
+            exit 1
+          fi
+
   bump:
+    needs: [guard]
+    if: always() && (needs.guard.result == 'success' || needs.guard.result == 'skipped')
     uses: josh-wong/actions/.github/workflows/bump-doc-versions-reusable.yaml@main
     with:
       product:     <PRODUCT>
       repo:        internal
-      minor:       ${{ github.event.client_payload.minor || github.ref_name }}
+      minor:       ${{ github.event.client_payload.minor || inputs.minor || github.ref_name }}
       to:          ${{ github.event.client_payload.to    || inputs.to }}
       from:        ${{ github.event.client_payload.from  || inputs.from }}
-      base_branch: ${{ github.event.client_payload.minor || github.ref_name }}
-      head_branch: update-${{ github.event.client_payload.minor || github.ref_name }}-patch-version-to-${{ github.event.client_payload.to || inputs.to }}
-      pr_title: "[${{ github.event.client_payload.minor || github.ref_name }}] Change patch version from `${{ github.event.client_payload.from || inputs.from }}` to `${{ github.event.client_payload.to || inputs.to }}`"
+      base_branch: ${{ github.ref_name }}
+      head_branch: update-${{ github.event.client_payload.minor || inputs.minor || github.ref_name }}-version-to-${{ github.event.client_payload.to || inputs.to }}
+      pr_title: "[${{ github.event.client_payload.minor || inputs.minor || github.ref_name }}] Update version references from `${{ github.event.client_payload.from || inputs.from }}` to `${{ github.event.client_payload.to || inputs.to }}`"
       pr_body_style: internal
       dry_run: ${{ inputs.dry_run || false }}
     secrets:


### PR DESCRIPTION
## Summary

Loosens the previously patch-only bump script + internal-caller template to support **cross-minor rewrites** (minor and major version bumps), initiated exclusively via manual `workflow_dispatch` on the internal repo.

Reason it wasn't in scope earlier: at bump time for a new minor or major, there's no `className` entry yet in `docusaurus.config.js` (that entry is added later as part of the structural release step). So the automated `className`-diff detector can't drive minor/major bumps by construction \u2014 they're always human-initiated via `workflow_dispatch`.

## What now works

| From dropdown | `from` | `to` | `minor` input | Effect |
|---|---|---|---|---|
| `3.17` | *(derived)* | `3.17.4` | *(defaults to 3.17)* | Patch bump 3.17.X \u2192 3.17.4 (same as before) |
| `3` | `3.18.5` | `3.19.0` | `3.19` | Minor bump on the `3` branch, PR labeled `[3.19]` |
| `main` | `3.18.5` | `4.0.0` | `4.0` | Major bump on `main`, PR labeled `[4.0]` |

## Semantic changes

### `bump-doc-versions.mjs`

- **Scope-guard filter** now driven by `--from`'s X.Y (source minor), not `--minor`. Backward-compatible for patch bumps.
- **`--minor` semantics** relaxed on internal: any string accepted (branch name). Public still requires `X.Y` or `current`.
- **`--to`** may have a different X.Y than `--from`'s X.Y on internal (cross-minor). Public still enforces same-minor.
- **Auto-derivation of `--from`** only works when `--minor` is `X.Y` form. For branch names like `main` or `3`, `--from` must be explicit.
- **New report fields:** `sourceMinor`, `targetMinor`, `crossMinor`.
- **Cross-minor warning** printed at the top of every cross-minor run.

### `build-pr-body.mjs`

- When `crossMinor` is true, prepends a **\u26a0\ufe0f banner** to the PR body explaining the broader scope-guard.
- Generic wording ("Update version references from X to Y") replaces the old "Change patch version" phrasing so the template works for all three bump types.

### `sample-usage.yaml` (internal-caller template only)

- Adds optional `minor` `workflow_dispatch` input for target-minor label override.
- Adds a `guard` job that rejects `workflow_dispatch` runs from non-X.Y branches unless the `minor` input is provided (nicer error than the previous "safe failure with ugly message").
- Renames `pr_title` and `head_branch` to bump-type-agnostic forms.

### `README.md`

Updated flag table, scope-guard description, and internal-caller description.

### Local reference docs also updated (tmp/ is gitignored, not in this PR)

- [`tmp/version-bump-automation-proposal.md`](https://github.com/josh-wong/actions/blob/support-minor-major-bumps/tmp/version-bump-automation-proposal.md) \u2014 revised \u00a73.3 (trigger) and \u00a75 (what's not automated).
- [`tmp/version-bump-automation-design.md`](https://github.com/josh-wong/actions/blob/support-minor-major-bumps/tmp/version-bump-automation-design.md) \u2014 \u00a72.2, \u00a76.1.1, \u00a76.1.4, \u00a76.4, \u00a78, \u00a711 (new E15/E16/E17), \u00a712, \u00a714.4, \u00a715.

## Not touched

- **Reusable workflow (`bump-doc-versions-reusable.yaml`)** \u2014 unchanged. It's a pipe; passes `--minor` / `--to` / `--from` through to the script.
- **Public-caller template (block \u2460 in `sample-usage.yaml`)** \u2014 unchanged. Its automated flow is patch-only by design.
- **`detect-classname-diff.mjs`** \u2014 unchanged. Its refusal of minor-spanning className diffs remains correct.

## Verified locally

| Scenario | Result |
|---|---|
| Patch bump (3.17.2 \u2192 3.17.99 on `3.17`) | 39 files, 139 replacements, `crossMinor: false`, identical to previous behavior |
| Cross-minor without `--from` | Exits 3 with helpful message: *`--from is required when --minor is not in X.Y form\u2026`* |
| Cross-minor with `--from` (3.17.2 \u2192 3.19.0) | 39 files, 139 replacements, `crossMinor: true`, cross-minor banner in log and PR body |

## Follow-up consumer PR

- `josh-wong/docs-internal-scalardb` \u2014 update `.github/workflows/bump-doc-versions.yml` on `main` and backport to `3.14`\u2013`3.18`. Coming in the next PR.