### PR TITLE
Extend P10 gate to accept placeholder-style anchors

### DIFF
--- a/bump-doc-versions/lib/patterns.mjs
+++ b/bump-doc-versions/lib/patterns.mjs
@@ -137,6 +137,31 @@ function scanP10(content, minor) {
   return matches;
 }
 
+// Detects Scalar-specific "placeholder-style" anchors — Maven coords, Docker
+// tags, Javadoc URLs, etc. where the version segment is a `<UPPER_CASE_VAR>`
+// placeholder instead of a concrete X.Y.Z. Used solely to gate P10 (prose
+// enumeration) in tutorial / template files that use placeholders in code
+// blocks and rely on prose like ``for example, `3.17.0` `` to convey the
+// version. Never used to drive rewrites directly.
+const PLACEHOLDER_ANCHOR_REGEXES = [
+  // Maven coordinate: com.scalar-labs:<artifact>:<PLACEHOLDER>
+  /com\.scalar-labs:[^:\s'"`)]+:<[A-Z][A-Z0-9_]*>/,
+  // Docker image with placeholder tag: ghcr.io/scalar-labs/<image>:<PLACEHOLDER>
+  /ghcr\.io\/scalar-labs\/[^:\s'"`)]+:<[A-Z][A-Z0-9_]*>/,
+  // Javadoc URL with placeholder version: javadoc.io/doc/com.scalar-labs/<artifact>/<PLACEHOLDER>
+  /javadoc\.io\/doc\/com\.scalar-labs\/[^/\s'"`)]+\/<[A-Z][A-Z0-9_]*>/,
+  // JAR filename with placeholder version: scalardb-…-<PLACEHOLDER>[-all].jar
+  /(?:scalardb|scalardl)-[^\s'"`)]*<[A-Z][A-Z0-9_]*>[^\s'"`)]*\.jar/,
+  // GitHub release URL with placeholder version
+  /github\.com\/scalar-labs\/[^/\s]+\/releases\/(?:tag|download)\/v?<[A-Z][A-Z0-9_]*>/,
+  // Shell env-var assignment with placeholder value
+  /SCALAR_(?:DB|DL)(?:_CLUSTER)?_VERSION=<[A-Z][A-Z0-9_]*>/,
+];
+
+function hasPlaceholderAnchor(content) {
+  return PLACEHOLDER_ANCHOR_REGEXES.some((rx) => rx.test(content));
+}
+
 /**
  * Match all patterns in a file's content for the given minor.
  * Returns { matches: [{pattern, offset, length, oldStr, oldVer, line}], skipped }
@@ -169,8 +194,13 @@ export function matchFile(content, minor, config) {
   }
   raw.push(...scanP2(content, minor));
 
-  // Gate P10 on having at least one P1–P9 same-minor match in the file
-  if (raw.length > 0) {
+  // Gate P10 on the file containing either:
+  //   (a) at least one P1–P9 same-minor match (a concrete anchored ref), or
+  //   (b) at least one placeholder-style anchor like `com.scalar-labs:foo:<VERSION>`
+  //       (tutorial / template files that convey the version through prose only).
+  // P10's own scope-guard still requires the bare X.Y.Z to match the source minor,
+  // so this loosening only affects _which files_ P10 examines, not _what it rewrites_.
+  if (raw.length > 0 || hasPlaceholderAnchor(content)) {
     const p10 = scanP10(content, minor);
     // Exclude P10 matches that overlap with any P1–P9 match (avoids double-counting
     // the bare X.Y.Z that lives inside an anchored URL / coordinate / etc.)


### PR DESCRIPTION
When you ran Test A.2, the internal bump [PR #10](https://github.com/josh-wong/docs-internal-scalardb/pull/10) missed 4 files that the reference production PR [scalar-labs/docs-internal-scalardb#2648](https://github.com/scalar-labs/docs-internal-scalardb/pull/2648) had rewritten:

- `docs/en-us/scalardb-analytics/deployment.mdx`
- `docs/en-us/scalardb-analytics/run-analytical-queries.mdx`
- `docs/ja-jp/scalardb-analytics/deployment.mdx`
- `docs/ja-jp/scalardb-analytics/run-analytical-queries.mdx`

## Root cause

Those files use placeholder variables like

```
com.scalar-labs:scalardb-analytics-spark-all-<SPARK_VERSION>_<SCALA_VERSION>:<SCALARDB_ANALYTICS_VERSION>
```

in code blocks, and describe the version through prose:

- **EN:** ``- `<SCALARDB_ANALYTICS_VERSION>`: The ScalarDB Analytics version (for example, `3.17.0`)``
- **JA:** ``- `<SCALARDB_ANALYTICS_VERSION>`: ScalarDB Analytics のバージョン (例: `3.17.1`)``

The P10 gate (prose enumeration) previously required at least one **concrete** P1–P9 anchored match for the source minor in the same file — so tutorial/template files that never spell out a concrete version were skipped, and the prose refs were never rewritten.

## Fix

Gate P10 on **either** (a) a concrete P1–P9 same-minor match (previous behavior), **or** (b) any placeholder-style anchor detected in the file:

- `com.scalar-labs:<artifact>:<PLACEHOLDER>`
- `ghcr.io/scalar-labs/<image>:<PLACEHOLDER>`
- `javadoc.io/doc/com.scalar-labs/<artifact>/<PLACEHOLDER>`
- `<scalardb|scalardl>-…-<PLACEHOLDER>[-all].jar`
- `github.com/scalar-labs/<repo>/releases/(tag|download)/v?<PLACEHOLDER>`
- `SCALAR_(DB|DL)(_CLUSTER)?_VERSION=<PLACEHOLDER>`

Where `<PLACEHOLDER>` is a `<UPPER_CASE_UNDERSCORE_DIGIT>` variable.

## Safety property preserved

The placeholder-anchor detection is used **solely** to gate P10 — never to drive rewrites directly. P10's own source-minor filter (`X.Y === --from`'s X.Y`) still governs which bare `X.Y.Z` occurrences get rewritten. The loosening only expands which _files_ P10 examines, not _what it rewrites_.

Concretely: a file with `com.scalar-labs:foo:<VERSION>` + bare `3.17.0` in prose gets caught. A file with the same placeholder + bare `3.16.0` in prose while we're bumping the `3.17` minor is left alone.

## Verified locally

Ran `--product scalardb --repo internal --minor 3.17 --from 3.17.2 --to 3.17.99` against `docs-internal-scalardb@3.17`:

| Metric | Before | After | Production PR #2648 |
|---|---|---|---|
| Files | 39 | **43** | 43 ✅ |
| Replacements | 139 | **148** | 148 ✅ |
| Pattern breakdown | P1/P2/P3/P4/P6/P7/P8 | Adds **P10=9** | matches |

**Exact parity** with the production PR — same 43 files, same 148 replacements.

## No consumer PRs

Change is entirely in the shared script. Reusable workflow and both caller workflows unchanged.

## Also updated (local reference docs, gitignored)

- `tmp/version-bump-automation-design.md` §6.1.4 — describes the extended gate
- `tmp/version-bump-automation-test-plan.md` A.1 — notes the counts should now match production