### PR TITLE
Add P11 (bare X.Y) + extended file gate for cross-minor bumps

### DIFF
--- a/bump-doc-versions/README.md
+++ b/bump-doc-versions/README.md
@@ -76,7 +76,7 @@ node bump-doc-versions/bump-doc-versions.mjs \
 
 ### Anchored patterns
 
-All ten patterns are enumerated in the design doc. In short:
+All eleven patterns are enumerated in the design doc. In short:
 
 | ID | What it matches | Example |
 |---|---|---|
@@ -88,10 +88,11 @@ All ten patterns are enumerated in the design doc. In short:
 | `P6` | Javadoc URL | `javadoc.io/doc/com.scalar-labs/scalardb-sql/3.17.2/…` |
 | `P7` | JAR filename | `scalardb-cluster-schema-loader-3.17.2-all.jar` |
 | `P8` | Shell env-var assignment | `SCALAR_DB_CLUSTER_VERSION=3.17.2` |
-| `P9` | Analytics Spark trailing version | `com.scalar-labs:scalardb-analytics-spark-all-3.5_2.12:3.17.2` (via `mavenArtifactsRegex`) |
-| `P10` | Bare `X.Y.Z` in prose | `"ScalarDB 3.16.5, 3.17.3, or 3.18.0"` — gated on the file having at least one P1–P9 same-minor match |
+| `P9` | Analytics Spark trailing version (only the trailing `X.Y.Z` is rewritten; the embedded `{SPARK}_{SCALA}` segment is left untouched) | `com.scalar-labs:scalardb-analytics-spark-all-3.5_2.12:3.17.2` |
+| `P10` | Bare `X.Y.Z` in prose | `"ScalarDB 3.16.5, 3.17.3, or 3.18.0"` — file-level gate: same-minor P1–P9 hit, placeholder anchor, or minor-density ≥ 3 (see design §6.1.4) |
+| `P11` | Bare `X.Y` in prose (**cross-minor bumps only**) | `"Combination of ScalarDB Cluster 3.17 and client SDK 3.14"` → `"…3.19 and client SDK 3.14"`; same file-level gate as P10 |
 
-**Scope guard:** for every pattern except P10, only occurrences where `X.Y === --from`'s X.Y are rewritten (i.e., the source minor). For a same-minor patch bump on the `3.17` branch, `3.16.5` and `3.18.0` in a prose line are left alone. For a cross-minor bump (e.g., `--from 3.18.5 --to 3.19.0` on `main`), all `3.18.X` references get rewritten to `3.19.0`, while `3.17.X` and `3.19.X` mentions are left alone.
+**Scope guard:** for every pattern except P11, only occurrences where `X.Y === --from`'s X.Y are rewritten (i.e., the source minor). For a same-minor patch bump on the `3.17` branch, `3.16.5` and `3.18.0` in a prose line are left alone. For a cross-minor bump (e.g., `--from 3.18.5 --to 3.19.0` on `main`), all `3.18.X` references get rewritten to `3.19.0`, while `3.17.X` and `3.19.X` mentions are left alone. P11 additionally rewrites bare source-minor `X.Y` references directly to the target-minor `X.Y`, and only fires on cross-minor bumps (a same-minor P11 would be a no-op that could strip a bare minor down to `X.Y.Z`).
 
 **Cross-minor bumps** (minor or major): the script logs a `⚠️ cross-minor bump` warning and the generated PR body includes the same warning banner. `--from` must be provided explicitly — auto-detection only supports same-minor bumps.
 

--- a/bump-doc-versions/README.md
+++ b/bump-doc-versions/README.md
@@ -45,8 +45,8 @@ node bump-doc-versions/bump-doc-versions.mjs \
 | `--product` | yes | `scalardb` or `scalardl`. Selects the product config file under `products/`. |
 | `--repo` | yes | `internal` or `public`. Selects the file-scope map (see below). |
 | `--minor` | yes | Scope selector. On `--repo public`: `X.Y` (e.g., `3.17`) or `current`. On `--repo internal`: any string — typically the branch name (`3.17`, `main`, `3`). Used as a label on internal (PR title / report); the actual match filter is driven by `--from`. |
-| `--to` | yes | New version to bump to (e.g., `3.17.4` for a patch, `3.19.0` for a minor, `4.0.0` for a major). Must satisfy `X.Y === --minor` on `--repo public`; may differ on `--repo internal` (cross-minor bumps are allowed there). |
-| `--from` | no | Current version to bump from (e.g., `3.17.3`). Auto-detected from `className` (public repo) or the first anchored match under `docs/en-us/**` (internal repo, `--minor` in `X.Y` form) when omitted. **Required for cross-minor bumps** on internal. Errors out if the auto-detection is ambiguous. |
+| `--to` | yes | New version to bump to (e.g., `3.17.4` for a patch, `3.19.0` for a minor, `4.0.0` for a major). Must satisfy `X.Y === --minor` on `--repo public`; may differ on `--repo internal` (cross-version bumps are allowed there). |
+| `--from` | no | Current version to bump from (e.g., `3.17.3`). Auto-detected from `className` (public repo) or the first anchored match under `docs/en-us/**` (internal repo, `--minor` in `X.Y` form) when omitted. **Required for cross-version bumps** on internal. Errors out if the auto-detection is ambiguous. |
 | `--root` | no | Root of the target repo. Defaults to `.`. |
 | `--dry-run` | no | Do not write files or update `className`. Report only. |
 | `--json-report <path>` | no | Write a machine-readable report to `<path>`. |
@@ -90,11 +90,11 @@ All eleven patterns are enumerated in the design doc. In short:
 | `P8` | Shell env-var assignment | `SCALAR_DB_CLUSTER_VERSION=3.17.2` |
 | `P9` | Analytics Spark trailing version (only the trailing `X.Y.Z` is rewritten; the embedded `{SPARK}_{SCALA}` segment is left untouched) | `com.scalar-labs:scalardb-analytics-spark-all-3.5_2.12:3.17.2` |
 | `P10` | Bare `X.Y.Z` in prose | `"ScalarDB 3.16.5, 3.17.3, or 3.18.0"` — file-level gate: same-minor P1–P9 hit, placeholder anchor, or minor-density ≥ 3 (see design §6.1.4) |
-| `P11` | Bare `X.Y` in prose (**cross-minor bumps only**) | `"Combination of ScalarDB Cluster 3.17 and client SDK 3.14"` → `"…3.19 and client SDK 3.14"`; same file-level gate as P10 |
+| `P11` | Bare `X.Y` in prose (**cross-version bumps only**) | `"Combination of ScalarDB Cluster 3.17 and client SDK 3.14"` → `"…3.19 and client SDK 3.14"`; same file-level gate as P10 |
 
-**Scope guard:** for every pattern except P11, only occurrences where `X.Y === --from`'s X.Y are rewritten (i.e., the source minor). For a same-minor patch bump on the `3.17` branch, `3.16.5` and `3.18.0` in a prose line are left alone. For a cross-minor bump (e.g., `--from 3.18.5 --to 3.19.0` on `main`), all `3.18.X` references get rewritten to `3.19.0`, while `3.17.X` and `3.19.X` mentions are left alone. P11 additionally rewrites bare source-minor `X.Y` references directly to the target-minor `X.Y`, and only fires on cross-minor bumps (a same-minor P11 would be a no-op that could strip a bare minor down to `X.Y.Z`).
+**Scope guard:** for every pattern except P11, only occurrences where `X.Y === --from`'s X.Y are rewritten (i.e., the source minor). For a same-minor patch bump on the `3.17` branch, `3.16.5` and `3.18.0` in a prose line are left alone. For a cross-version bump (e.g., `--from 3.18.5 --to 3.19.0` on `main`), all `3.18.X` references get rewritten to `3.19.0`, while `3.17.X` and `3.19.X` mentions are left alone. P11 additionally rewrites bare source-minor `X.Y` references directly to the target-minor `X.Y`, and only fires on cross-version bumps (a same-minor P11 would be a no-op that could strip a bare minor down to `X.Y.Z`).
 
-**Cross-minor bumps** (minor or major): the script logs a `⚠️ cross-minor bump` warning and the generated PR body includes the same warning banner. `--from` must be provided explicitly — auto-detection only supports same-minor bumps.
+**Cross-version bumps** (minor or major): the script logs a `⚠️ cross-version bump` warning and the generated PR body includes the same warning as a GitHub `[!IMPORTANT]` admonition. `--from` must be provided explicitly — auto-detection only supports same-minor patch bumps.
 
 ### Ignore markers
 

--- a/bump-doc-versions/build-pr-body.mjs
+++ b/bump-doc-versions/build-pr-body.mjs
@@ -29,7 +29,9 @@ async function main() {
 
 function crossMinorBanner(r) {
   if (!r.crossMinor) return '';
-  return `> ⚠️ **Cross-minor bump.** This PR rewrites all \`${r.sourceMinor}.X\` references in scope to \`${r.to}\` (source minor \`${r.sourceMinor}\` → target minor \`${r.targetMinor}\`). Please verify the diff carefully — the scope-guard was relaxed to allow this cross-minor rewrite.\n\n`;
+  return `> [!IMPORTANT]
+>
+> ⚠️ **Cross-version bump.** This PR rewrites all \`${r.sourceMinor}.X\` references in scope to \`${r.to}\` (source minor \`${r.sourceMinor}\` → target minor \`${r.targetMinor}\`). Please verify the diff carefully — the scope-guard was relaxed to allow this cross-version rewrite.\n\n`;
 }
 
 function renderInternal(r) {
@@ -55,7 +57,7 @@ N/A
 
 ## Additional notes
 
-Opened automatically by [\`bump-doc-versions\`](https://github.com/josh-wong/actions/tree/main/bump-doc-versions)${r.crossMinor ? ' via a manual `workflow_dispatch` (cross-minor bump)' : ' in response to a `className` update on `main` of the public docs repo'}.
+Opened automatically by [\`bump-doc-versions\`](https://github.com/josh-wong/actions/tree/main/bump-doc-versions)${r.crossMinor ? ' via a manual `workflow_dispatch` (cross-version bump)' : ' in response to a `className` update on `main` of the public docs repo'}.
 
 ${renderVerification(r)}
 `;
@@ -82,9 +84,9 @@ function renderVerification(r) {
   lines.push(`- **Repo scope:** \`${r.repo}\``);
   lines.push(`- **Minor label:** \`${r.minor}\`${r.minorRequested && r.minorRequested !== r.minor ? ` (requested: \`${r.minorRequested}\`)` : ''}`);
   if (r.crossMinor) {
-    lines.push(`- **Bump kind:** cross-minor (source \`${r.sourceMinor}\` → target \`${r.targetMinor}\`)`);
+    lines.push(`- **Bump kind:** cross-version (source \`${r.sourceMinor}\` → target \`${r.targetMinor}\`)`);
   } else if (r.sourceMinor) {
-    lines.push(`- **Bump kind:** same-minor (\`${r.sourceMinor}\`)`);
+    lines.push(`- **Bump kind:** same-minor patch (\`${r.sourceMinor}\`)`);
   }
   lines.push(`- **From → To:** \`${r.from}\` → \`${r.to}\``);
   lines.push(`- **Dry run:** ${r.dryRun ? 'yes' : 'no'}`);

--- a/bump-doc-versions/bump-doc-versions.mjs
+++ b/bump-doc-versions/bump-doc-versions.mjs
@@ -121,7 +121,7 @@ async function main() {
       // (so we know what X.Y to scan for). For branch names like 'main' or
       // '3', the caller must pass --from.
       if (!/^\d+\.\d+$/.test(values.minor)) {
-        fail(3, `--from is required when --minor is not in X.Y form (got --minor '${values.minor}'). Auto-derivation only supports same-minor bumps on X.Y branches; for cross-minor (minor/major) bumps, pass --from explicitly.`);
+        fail(3, `--from is required when --minor is not in X.Y form (got --minor '${values.minor}'). Auto-derivation only supports same-minor patch bumps on X.Y branches; for cross-version (minor or major) bumps, pass --from explicitly.`);
       }
       const derived = await deriveFromInternal(root, effectiveMinor, config);
       if (derived.error) fail(3, derived.error);
@@ -153,7 +153,7 @@ async function main() {
   }
 
   if (isCrossMinor) {
-    console.log(`⚠️  Cross-minor bump: ${sourceMinor} → ${toMinor} (${fromVer} → ${values.to})`);
+    console.log(`⚠️  Cross-version bump: ${sourceMinor} → ${toMinor} (${fromVer} → ${values.to})`);
     console.log(`   The scope-guard filter uses source minor ${sourceMinor}; ALL ${sourceMinor}.X references in scope will be rewritten. Verify the diff carefully.`);
   }
 

--- a/bump-doc-versions/bump-doc-versions.mjs
+++ b/bump-doc-versions/bump-doc-versions.mjs
@@ -185,7 +185,7 @@ async function main() {
     const content = await fs.readFile(abs, 'utf8');
     // Match filter is driven by the source minor (from --from's X.Y),
     // not by --minor. Same value for patch bumps; differs for minor/major bumps.
-    const { matches, skipped } = matchFile(content, sourceMinor, config);
+    const { matches, skipped } = matchFile(content, sourceMinor, toMinor, config);
     const rel = path.relative(root, abs).split(path.sep).join('/');
 
     if (skipped) {
@@ -195,10 +195,14 @@ async function main() {
     if (matches.length === 0) continue;
 
     // Apply substitutions in reverse offset order so earlier offsets stay valid.
+    // Most patterns replace `oldVer` (X.Y.Z) with --to inside `oldStr`. P11
+    // (bare X.Y) uses `newVerOverride` (target minor X.Y) instead — otherwise
+    // we'd rewrite "3.17" to the full "3.19.0" instead of "3.19".
     let next = content;
     const patCounts = {};
     for (const m of matches.slice().reverse()) {
-      const replacement = m.oldStr.replace(m.oldVer, values.to);
+      const newVer = m.newVerOverride ?? values.to;
+      const replacement = m.oldStr.replace(m.oldVer, newVer);
       next = next.slice(0, m.offset) + replacement + next.slice(m.offset + m.length);
       patCounts[m.pattern] = (patCounts[m.pattern] || 0) + 1;
     }

--- a/bump-doc-versions/lib/patterns.mjs
+++ b/bump-doc-versions/lib/patterns.mjs
@@ -1,26 +1,26 @@
 // Anchored pattern matcher for bump-doc-versions.
 //
-// Implements P1–P10 from the version-bump-automation design doc §4.1.
+// Implements P1–P11 from the version-bump-automation design doc §4.1.
 // Each match carries { pattern, offset, length, oldStr, oldVer, line } so the caller can
 // apply substitutions in reverse offset order.
 //
-// Scope guard: for every pattern except P10, only rewrites where matched X.Y === --minor.
-// P10 gate: only rewrites bare X.Y.Z if the same file also contains a P1–P9 same-minor match
+// Scope guard: for every pattern except P11, only rewrites where matched X.Y === source-minor.
+// P10 / P11 file-level gate: only rewrites a bare X.Y.Z / X.Y if the same file also contains
+// a concrete P1–P9 same-minor match, a placeholder-style anchor, or has minor-density ≥ 3
 // (per design §6.1.4, which supersedes the tighter same-line wording in §4.1).
 
 const escRx = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
 /**
- * Builds anchored scanners P1, P3, P4, P5, P6, P7, P8 from a product config.
+ * Builds anchored scanners P1, P3–P9 from a product config.
  * Each scanner is { name, regex } where the regex captures (X.Y) in group 1 and (Z) in group 2.
- * P2 and P10 are handled separately because they need context (proximity / file-level gate).
+ * P2, P10, and P11 are handled separately because they need context
+ * (proximity / file-level gate / cross-minor guard).
  */
 export function buildScanners(config) {
-  const mavenParts = [
-    ...(config.mavenArtifacts || []).map(escRx),
-    ...(config.mavenArtifactsRegex || []), // already regex
-  ];
-  const mavenGroup = mavenParts.length ? `(?:${mavenParts.join('|')})` : null;
+  const mavenGroup = (config.mavenArtifacts || []).length
+    ? `(?:${config.mavenArtifacts.map(escRx).join('|')})`
+    : null;
   const ghcrGroup = (config.ghcrImages || []).length
     ? `(?:${config.ghcrImages.map(escRx).join('|')})`
     : null;
@@ -81,6 +81,16 @@ export function buildScanners(config) {
       regex: new RegExp(`${envGroup}=(\\d+\\.\\d+)\\.(\\d+)`, 'g'),
     });
   }
+
+  // P9: analytics-spark trailing version. The `-{SPARK}_{SCALA}` segment
+  // between the artifact and the trailing X.Y.Z is intentionally *not* captured
+  // — only the coord's trailing version is a rewrite target. This is a static
+  // scanner (like P2) because there's exactly one artifact family in this shape
+  // (`scalardb-analytics-spark-all`); a new one would call for a config field.
+  scanners.push({
+    name: 'P9',
+    regex: /com\.scalar-labs:scalardb-analytics-spark-all-\d+\.\d+_\d+\.\d+:(\d+\.\d+)\.(\d+)/g,
+  });
 
   return scanners;
 }
@@ -254,7 +264,7 @@ export function matchFile(content, sourceMinor, targetMinor, config) {
     return { matches: [], skipped: 'skip-file' };
   }
 
-  // Collect P1–P9 matches (P2 handled separately)
+  // Collect P1 and P3–P9 matches (P2 handled separately below)
   const scanners = buildScanners(config);
   const raw = [];
   for (const s of scanners) {

--- a/bump-doc-versions/lib/patterns.mjs
+++ b/bump-doc-versions/lib/patterns.mjs
@@ -137,6 +137,29 @@ function scanP10(content, minor) {
   return matches;
 }
 
+// P11: bare X.Y (no patch component). Fires only on cross-minor bumps —
+// on same-minor patch bumps the source and target X.Y are equal, so any
+// rewrite would be a no-op. The replacement is the target X.Y (e.g. "3.19"),
+// not the full X.Y.Z of --to, so we mark these matches with an explicit
+// `newVerOverride` for the substitution step to use.
+function scanP11(content, sourceMinor, targetMinor) {
+  if (sourceMinor === targetMinor) return [];
+  const rx = new RegExp(`(?<![\\d.])${escRx(sourceMinor)}(?![\\d.])`, 'g');
+  const matches = [];
+  let m;
+  while ((m = rx.exec(content)) !== null) {
+    matches.push({
+      pattern: 'P11',
+      offset: m.index,
+      length: m[0].length,
+      oldStr: m[0],
+      oldVer: sourceMinor,
+      newVerOverride: targetMinor,
+    });
+  }
+  return matches;
+}
+
 // Detects Scalar-specific "placeholder-style" anchors — Maven coords, Docker
 // tags, Javadoc URLs, etc. where the version segment is a `<UPPER_CASE_VAR>`
 // placeholder instead of a concrete X.Y.Z. Used solely to gate P10 (prose
@@ -162,12 +185,70 @@ function hasPlaceholderAnchor(content) {
   return PLACEHOLDER_ANCHOR_REGEXES.some((rx) => rx.test(content));
 }
 
+// Third gate branch: files that are clearly "about" a specific minor even
+// though they contain no anchored (P1–P9) or placeholder patterns —
+// e.g., compatibility matrices, requirements pages, migration guides.
+// If the file mentions the source minor ≥ MIN_MINOR_DENSITY times (in any
+// form — bare X.Y, X.Y.Z, or X.Y.Z-suffix), we consider it version-dense
+// enough that P10 / P11 should examine it.
+const MIN_MINOR_DENSITY = 3;
+
+function hasMinorDensity(content, minor) {
+  const rx = new RegExp(`(?<![\\d.])${escRx(minor)}(?:\\.\\d+)?(?![\\d.])`, 'g');
+  let count = 0;
+  let m;
+  while ((m = rx.exec(content)) !== null) {
+    if (++count >= MIN_MINOR_DENSITY) return true;
+  }
+  return false;
+}
+
+// Markdown table rows (start and end with `|`, allowing whitespace and
+// optional leading indentation) are treated as structural and excluded
+// from all pattern rewrites. Adding a new row for a new minor is a
+// human/structural task; the tool must not rewrite the existing rows.
+const TABLE_ROW_REGEX = /^\s*\|.*\|\s*$/;
+
+function collectTableRowLines(content) {
+  const table = new Set();
+  const lines = content.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    if (TABLE_ROW_REGEX.test(lines[i])) table.add(i + 1); // 1-based
+  }
+  return table;
+}
+
+// Section-scoped skip: everything between `<!-- version-bump: skip-section -->`
+// (inclusive) and the matching `<!-- version-bump: end-skip-section -->`
+// (inclusive) is excluded from all pattern rewrites. Used as an escape hatch
+// when the table-row heuristic gets the wrong verdict or when a stretch of
+// non-table content must be left untouched.
+function collectSkipSectionLines(content) {
+  const skipped = new Set();
+  const lines = content.split('\n');
+  let inSection = false;
+  for (let i = 0; i < lines.length; i++) {
+    if (!inSection && lines[i].includes('<!-- version-bump: skip-section -->')) {
+      inSection = true;
+    }
+    if (inSection) skipped.add(i + 1); // 1-based
+    if (inSection && lines[i].includes('<!-- version-bump: end-skip-section -->')) {
+      inSection = false;
+    }
+  }
+  return skipped;
+}
+
 /**
- * Match all patterns in a file's content for the given minor.
- * Returns { matches: [{pattern, offset, length, oldStr, oldVer, line}], skipped }
- * Applies file-level and per-line skip markers.
+ * Match all patterns in a file's content for the given source/target minor pair.
+ * Returns { matches: [{pattern, offset, length, oldStr, oldVer, line, newVerOverride?}], skipped }
+ * Applies file-level, per-line, section, and table-row skip logic.
+ *
+ * For same-minor patch bumps, sourceMinor === targetMinor (P11 becomes a no-op).
+ * For cross-minor (minor/major) bumps, sourceMinor !== targetMinor and P11
+ * rewrites bare X.Y references from source to target.
  */
-export function matchFile(content, minor, config) {
+export function matchFile(content, sourceMinor, targetMinor, config) {
   // File-level skip
   if (content.includes('<!-- version-bump: skip-file -->')) {
     return { matches: [], skipped: 'skip-file' };
@@ -182,7 +263,7 @@ export function matchFile(content, minor, config) {
     while ((m = s.regex.exec(content)) !== null) {
       const xy = m[1];
       const z = m[2];
-      if (xy !== minor) continue;
+      if (xy !== sourceMinor) continue;
       raw.push({
         pattern: s.name,
         offset: m.index,
@@ -192,16 +273,26 @@ export function matchFile(content, minor, config) {
       });
     }
   }
-  raw.push(...scanP2(content, minor));
+  raw.push(...scanP2(content, sourceMinor));
 
-  // Gate P10 on the file containing either:
+  // Gate P10 (and P11) on the file being "about" the source minor. Three
+  // sufficient signals; any one is enough:
   //   (a) at least one P1–P9 same-minor match (a concrete anchored ref), or
   //   (b) at least one placeholder-style anchor like `com.scalar-labs:foo:<VERSION>`
-  //       (tutorial / template files that convey the version through prose only).
-  // P10's own scope-guard still requires the bare X.Y.Z to match the source minor,
-  // so this loosening only affects _which files_ P10 examines, not _what it rewrites_.
-  if (raw.length > 0 || hasPlaceholderAnchor(content)) {
-    const p10 = scanP10(content, minor);
+  //       (tutorial / template files that convey the version through prose only),
+  //   (c) minor-density signal: source-minor mentioned in the file ≥ N times
+  //       (matrix pages, requirements pages, migration guides — high-signal
+  //       files that lack coordinates but are clearly version-specific).
+  // The scope-guards on P10 (X.Y === source-minor) and P11 (bare X.Y ===
+  // source-minor, cross-minor only) still restrict what actually gets rewritten,
+  // so a lenient gate only affects _which files_ are examined.
+  const gateOpen =
+    raw.length > 0 ||
+    hasPlaceholderAnchor(content) ||
+    hasMinorDensity(content, sourceMinor);
+
+  if (gateOpen) {
+    const p10 = scanP10(content, sourceMinor);
     // Exclude P10 matches that overlap with any P1–P9 match (avoids double-counting
     // the bare X.Y.Z that lives inside an anchored URL / coordinate / etc.)
     const covered = intervals(raw);
@@ -210,16 +301,31 @@ export function matchFile(content, minor, config) {
         raw.push(m);
       }
     }
+    // P11 (bare X.Y) — cross-minor bumps only. Exclude matches that overlap
+    // any previously collected match (X.Y is a prefix of X.Y.Z, so we must
+    // avoid double-counting the "3.17" that lives inside "3.17.2").
+    const p11 = scanP11(content, sourceMinor, targetMinor);
+    const coveredWithP10 = intervals(raw);
+    for (const m of p11) {
+      if (!overlapsAny(m.offset, m.offset + m.length, coveredWithP10)) {
+        raw.push(m);
+      }
+    }
   }
 
-  // Attach line numbers (1-based) and apply per-line skip markers.
+  // Attach line numbers (1-based) and apply skip logic: per-line marker,
+  // section markers, and the Markdown-table-row heuristic.
   const lineStarts = computeLineStarts(content);
   const skipLines = collectSkipLines(content);
+  const skipSectionLines = collectSkipSectionLines(content);
+  const tableRowLines = collectTableRowLines(content);
 
   const kept = [];
   for (const m of raw) {
     const line = binarySearchLine(lineStarts, m.offset);
     if (skipLines.has(line)) continue;
+    if (skipSectionLines.has(line)) continue;
+    if (tableRowLines.has(line)) continue;
     kept.push({ ...m, line });
   }
 

--- a/bump-doc-versions/products/scalardb.json
+++ b/bump-doc-versions/products/scalardb.json
@@ -14,9 +14,6 @@
     "scalardb-sql-jdbc",
     "scalardb-sql-spring-data"
   ],
-  "mavenArtifactsRegex": [
-    "scalardb-analytics-spark-all-\\d+\\.\\d+_\\d+\\.\\d+"
-  ],
   "ghcrImages": [
     "scalardb-cluster-node-byol-premium",
     "scalardb-cluster-node-byol-standard",

--- a/bump-doc-versions/products/scalardl.json
+++ b/bump-doc-versions/products/scalardl.json
@@ -8,7 +8,6 @@
     "scalardl-java-client-sdk",
     "scalardl-common"
   ],
-  "mavenArtifactsRegex": [],
   "ghcrImages": [
     "scalardl-ledger",
     "scalardl-auditor"

--- a/bump-doc-versions/sample-usage.yaml
+++ b/bump-doc-versions/sample-usage.yaml
@@ -153,7 +153,7 @@ on:
         required: true
         type: string
       from:
-        description: 'Current version to bump from (e.g., "3.17.3"). REQUIRED when dispatching from "main" or "3" (cross-minor bumps); auto-detected otherwise from an anchored match in this repo.'
+        description: 'Current version to bump from (e.g., "3.17.3"). REQUIRED when dispatching from "main" or "3" (cross-version bumps); auto-detected otherwise from an anchored match in this repo.'
         required: false
         type: string
         default: ''
@@ -178,7 +178,7 @@ jobs:
     # Two cases:
     #   1. Dispatched from an X.Y branch (3.14, …, 3.18): same-minor patch bump.
     #      Both `minor` and `from` are optional — the script auto-derives them.
-    #   2. Dispatched from a non-X.Y branch (`main`, `3`): cross-minor bump.
+    #   2. Dispatched from a non-X.Y branch (`main`, `3`): cross-version bump.
     #      Both `minor` and `from` are required — the branch dropdown carries
     #      no version info, and auto-detection can't tell 3.18 apart from 3.19.
     # Skipped on repository_dispatch (client_payload always carries `minor`).
@@ -201,7 +201,7 @@ jobs:
             problems=1
           fi
           if [ -z "$FROM_INPUT" ]; then
-            echo "::error::'from' input is required when dispatching from '${GITHUB_REF_NAME}' (cross-minor bumps can't auto-detect the source version). Provide the current source version (e.g., '3.17.3')."
+            echo "::error::'from' input is required when dispatching from '${GITHUB_REF_NAME}' (cross-version bumps can't auto-detect the source version). Provide the current source version (e.g., '3.17.3')."
             problems=1
           fi
           exit $problems


### PR DESCRIPTION
## Motivation

During a `3.17 → 3.19` cross-minor bump on `docs-internal-scalardb`, bare `X.Y` prose references like `Combination of ScalarDB Cluster 3.17 and client SDK 3.14` were left behind, and the entire `compatibility.mdx` file was skipped because it has no anchored coordinates.

Both symptoms stemmed from the same root cause: **P10 was the only pattern that could touch prose, it required an anchored ref to be present in the file, and it only matched full X.Y.Z triples.**

## Changes

Four coordinated mechanisms:

### 1. New pattern P11 (bare `X.Y`)

- Matches a bare X.Y where X.Y equals the source minor
- **Cross-minor only** — no-op when `sourceMinor === targetMinor` (otherwise a bare `3.17` on a patch bump would become `3.17.2`, stripping down the minor)
- Rewrites to the **target minor** X.Y directly (not to `values.to`, since `3.17 → 3.19.0` would be wrong)
- Overlap-deduped against P1–P10 so the `3.17` inside `3.17.2` isn't double-counted

### 2. Extended file-level gate for P10 and P11

Three sufficient signals; any one is enough:

1. At least one P1–P9 same-minor anchored match (concrete coordinate)
2. Placeholder-style anchor like `com.scalar-labs:foo:<VERSION>` (tutorial/template files)
3. **Minor-density signal (new)** — source-minor X.Y mentioned ≥ 3 times in the file

The density gate lets high-signal prose files (compatibility matrix, requirements pages, migration guides) participate without needing a coordinate anchor. Pattern scope-guards still restrict what actually gets rewritten.

### 3. Markdown-table-row auto-exclusion

Any line matching \`^\s*\|.*\|\s*\$\` is excluded from every pattern.

Rationale: compat-matrix rows like \`| 3.17 | 3.14 - 3.17 |\` are **structural** references — the correct migration for a minor bump is to _add_ a new \`3.19\` row, not to overwrite the \`3.17\` row. Aligns with the original design's §4.4 principle that structural mentions (release-notes titles, matrix rows, changelog entries) are left alone.

### 4. Section-marker escape hatch

Wrap a region in \`<!-- version-bump: skip-section -->\` … \`<!-- version-bump: end-skip-section -->\` to opt-out an arbitrary block from all rewrites. Useful when a file has both prose the script should rewrite and a nearby region referencing a specific historical version.

## Verification

Local smoke tests on \`josh-wong/docs-internal-scalardb\`:

**Regression (patch bump, same behavior expected):**
\`\`\`
3.17.2 → 3.17.99 on branch 3.17
→ 43 files, 148 replacements
→ P1=30 P2=24 P3=13 P4=16 P6=20 P7=34 P8=2 P10=9
→ crossMinor: false, P11 does not fire
\`\`\`
Byte-identical to previous behavior.

**Cross-minor (new capability):**
\`\`\`
3.17.2 → 3.19.0 on branch '3'
→ 2 files, 12 replacements (both compatibility.mdx EN + JA)
→ P10=8 P11=4
→ crossMinor: true
\`\`\`

The compat file diff:
\`\`\`diff
-  - **Supported:** Combination of ScalarDB Cluster 3.17 and client SDK 3.14
-  - **Not supported:** Combination of ScalarDB Cluster 3.14 and client SDK 3.17
+  - **Supported:** Combination of ScalarDB Cluster 3.19 and client SDK 3.14
+  - **Not supported:** Combination of ScalarDB Cluster 3.14 and client SDK 3.19
-  - **Supported:** Combination of ScalarDB Cluster 3.17.2 and client SDK 3.17.0
-  - **Supported:** Combination of ScalarDB Cluster 3.17.0 and client SDK 3.17.2
+  - **Supported:** Combination of ScalarDB Cluster 3.19.0 and client SDK 3.19.0
+  - **Supported:** Combination of ScalarDB Cluster 3.19.0 and client SDK 3.19.0
\`\`\`

Matrix rows on lines 14–19 (\`| 3.17 | 3.14 - 3.17 | ... |\`, etc.) — completely preserved. Only the four prose lines rewritten. No unintended edits.