### PR TITLE
Redesign caller model: workflow file lives on main only

### DIFF
--- a/bump-doc-versions/README.md
+++ b/bump-doc-versions/README.md
@@ -116,7 +116,7 @@ The reusable workflow lives at [`.github/workflows/bump-doc-versions-reusable.ya
 
 See [`sample-usage.yaml`](./sample-usage.yaml) for ready-to-copy caller workflows:
 
-- **Internal repo caller** — `docs-internal-scalardb/.github/workflows/bump-doc-versions.yml`. Accepts a `repository_dispatch` from the public repo (patch bumps only) or a manual `workflow_dispatch` (patch, minor, or major bumps). The target minor is derived from `github.event.client_payload.minor` (automated flow), an optional `minor` input (explicit override), or `github.ref_name` (branch selected in the **"Use workflow from"** dropdown), in that order. For the manual path to work from a version branch, this file must be present on every active version branch (`3.14`, `3.15`, …, `3.18`) in addition to `main` (and `3` if you use that for the next-minor line).
+- **Internal repo caller** — `docs-internal-scalardb/.github/workflows/bump-doc-versions.yml`. Accepts a `repository_dispatch` from the public repo (patch bumps only) or a manual `workflow_dispatch` (patch, minor, or major bumps). **Lives on `main` only** — every dispatch supplies the target branch as data (either `client_payload.minor` for `repository_dispatch`, which doubles as the version branch name for patch bumps, or the required `target_branch` input for `workflow_dispatch`). No per-version-branch duplication of the caller is needed.
 - **Public repo caller** — `docs-scalardb/.github/workflows/trigger-version-bump.yml`. Detects a `className` change in `docusaurus.config.js` on push to `main`, extracts `(minor, from, to)`, `repository_dispatch`es into the internal repo, and runs a safety-net bump on the public repo itself.
 
 ### Tokens

--- a/bump-doc-versions/sample-usage.yaml
+++ b/bump-doc-versions/sample-usage.yaml
@@ -134,12 +134,18 @@ jobs:
 # Runs on repository_dispatch from the public repo (patch bumps only),
 # or on manual workflow_dispatch (patch, minor, and major bumps).
 #
-# For workflow_dispatch to work from a version branch, this file must
-# exist on every active version branch (e.g., 3.14–3.18) — the "Use
-# workflow from" dropdown then supplies the minor via github.ref_name.
-# For minor / major bumps (which have no version branch yet), dispatch
-# from `main` (major) or `3` (next minor) and provide the optional
-# `minor` input to label the PR (e.g., "3.19" or "4.0").
+# Lives on `main` only. Every dispatch supplies the target branch as
+# data (either `client_payload.minor` for repository_dispatch, or the
+# `target_branch` input for workflow_dispatch), so the workflow never
+# has to be duplicated onto each version branch.
+#
+# Dispatch model at a glance:
+#   - Patch bump (X.Y.Z1 → X.Y.Z2): target_branch = "3.17" (the version branch).
+#     `minor` and `from` may be omitted; the script auto-derives them.
+#   - Minor bump  (3.18.X → 3.19.0): target_branch = "3" (next-minor branch).
+#     Provide `minor: 3.19` and `from: 3.18.X` explicitly.
+#   - Major bump  (3.18.X → 4.0.0): target_branch = "main".
+#     Provide `minor: 4.0` and `from: 3.18.X` explicitly.
 
 name: 🔢 Bump version references in docs
 
@@ -148,17 +154,21 @@ on:
     types: [bump-patch]
   workflow_dispatch:
     inputs:
+      target_branch:
+        description: 'Branch to bump on and open the PR against (e.g., "3.17" for a patch, "3" for a minor, "main" for a major)'
+        required: true
+        type: string
       to:
         description: 'New version to bump to (e.g., "3.17.4" for a patch, "3.19.0" for a minor, "4.0.0" for a major)'
         required: true
         type: string
       from:
-        description: 'Current version to bump from (e.g., "3.17.3"). REQUIRED when dispatching from "main" or "3" (cross-version bumps); auto-detected otherwise from an anchored match in this repo.'
+        description: 'Current version to bump from (e.g., "3.17.3"). REQUIRED when target_branch is not an X.Y branch (i.e., "main" or "3" — cross-version bumps); auto-detected otherwise from an anchored match in this repo.'
         required: false
         type: string
         default: ''
       minor:
-        description: 'Target minor label for the PR title (e.g., "3.19" or "4.0"). REQUIRED when dispatching from "main" or "3"; auto-derived otherwise from the "Use workflow from" branch name.'
+        description: 'Target minor label for the PR title (e.g., "3.19" or "4.0"). REQUIRED when target_branch is not an X.Y branch; auto-derived otherwise from target_branch.'
         required: false
         type: string
         default: ''
@@ -174,34 +184,35 @@ permissions:
 
 jobs:
   guard:
-    # Validates workflow_dispatch inputs against the branch you dispatched from.
+    # Validates workflow_dispatch inputs against `target_branch`.
     # Two cases:
-    #   1. Dispatched from an X.Y branch (3.14, …, 3.18): same-minor patch bump.
+    #   1. target_branch is an X.Y branch (3.14, …, 3.18): same-minor patch bump.
     #      Both `minor` and `from` are optional — the script auto-derives them.
-    #   2. Dispatched from a non-X.Y branch (`main`, `3`): cross-version bump.
-    #      Both `minor` and `from` are required — the branch dropdown carries
-    #      no version info, and auto-detection can't tell 3.18 apart from 3.19.
+    #   2. target_branch is a non-X.Y branch (`main`, `3`): cross-version bump.
+    #      Both `minor` and `from` are required — the branch name carries no
+    #      version info, and auto-detection can't tell 3.18 apart from 3.19.
     # Skipped on repository_dispatch (client_payload always carries `minor`).
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - name: Validate dispatch context
         env:
-          MINOR_INPUT: ${{ inputs.minor }}
-          FROM_INPUT:  ${{ inputs.from }}
+          TARGET_BRANCH: ${{ inputs.target_branch }}
+          MINOR_INPUT:   ${{ inputs.minor }}
+          FROM_INPUT:    ${{ inputs.from }}
         run: |
-          # Case 1: X.Y branch — always valid.
-          if [[ "${GITHUB_REF_NAME}" =~ ^[0-9]+\.[0-9]+$ ]]; then
+          # Case 1: X.Y target branch — always valid.
+          if [[ "${TARGET_BRANCH}" =~ ^[0-9]+\.[0-9]+$ ]]; then
             exit 0
           fi
-          # Case 2: non-X.Y branch — both `minor` and `from` are required.
+          # Case 2: non-X.Y target branch — both `minor` and `from` are required.
           problems=0
           if [ -z "$MINOR_INPUT" ]; then
-            echo "::error::'minor' input is required when dispatching from '${GITHUB_REF_NAME}'. Provide an explicit target-minor label (e.g., '3.19' or '4.0')."
+            echo "::error::'minor' input is required when target_branch is '${TARGET_BRANCH}' (non-X.Y). Provide an explicit target-minor label (e.g., '3.19' or '4.0')."
             problems=1
           fi
           if [ -z "$FROM_INPUT" ]; then
-            echo "::error::'from' input is required when dispatching from '${GITHUB_REF_NAME}' (cross-version bumps can't auto-detect the source version). Provide the current source version (e.g., '3.17.3')."
+            echo "::error::'from' input is required when target_branch is '${TARGET_BRANCH}' (cross-version bumps can't auto-detect the source version). Provide the current source version (e.g., '3.17.3')."
             problems=1
           fi
           exit $problems
@@ -213,12 +224,16 @@ jobs:
     with:
       product:     <PRODUCT>
       repo:        internal
-      minor:       ${{ github.event.client_payload.minor || inputs.minor || github.ref_name }}
+      # Target branch is passed as data by both event paths:
+      #   - repository_dispatch: client_payload.minor doubles as the branch name
+      #     (patch bumps always target an X.Y branch that equals the minor).
+      #   - workflow_dispatch: inputs.target_branch is the explicit user choice.
+      minor:       ${{ github.event.client_payload.minor || inputs.minor || inputs.target_branch }}
       to:          ${{ github.event.client_payload.to    || inputs.to }}
       from:        ${{ github.event.client_payload.from  || inputs.from }}
-      base_branch: ${{ github.ref_name }}
-      head_branch: update-${{ github.event.client_payload.minor || inputs.minor || github.ref_name }}-version-to-${{ github.event.client_payload.to || inputs.to }}
-      pr_title: "[${{ github.event.client_payload.minor || inputs.minor || github.ref_name }}] Update version references from `${{ github.event.client_payload.from || inputs.from }}` to `${{ github.event.client_payload.to || inputs.to }}`"
+      base_branch: ${{ github.event.client_payload.minor || inputs.target_branch }}
+      head_branch: update-${{ github.event.client_payload.minor || inputs.minor || inputs.target_branch }}-version-to-${{ github.event.client_payload.to || inputs.to }}
+      pr_title: "[${{ github.event.client_payload.minor || inputs.minor || inputs.target_branch }}] Update version references from `${{ github.event.client_payload.from || inputs.from }}` to `${{ github.event.client_payload.to || inputs.to }}`"
       pr_body_style: internal
       dry_run: ${{ inputs.dry_run || false }}
     secrets:


### PR DESCRIPTION
Follow-up to #112.

## Motivation

The sample caller (`sample-usage.yaml`) and README described a model where the caller workflow had to be **duplicated onto every version branch**, because it derived the target branch from `github.ref_name`. Every user-facing wording change to the caller had to be cherry-picked onto six version branches — a real drift risk that already caught us on the "cross-minor → cross-version" rename.

## Change

Single source of truth: the caller lives only on `main`. The target branch is passed as **data**:

- **`workflow_dispatch`**: new required `target_branch` input. User always dispatches from `main`; the input steers the actual work.
- **`repository_dispatch`**: `client_payload.minor` doubles as the target-branch name (patch bumps always target an X.Y branch equal to the minor).

Dispatch matrix:

| Bump kind | `target_branch` | `minor` input | `from` input |
|---|---|---|---|
| Patch (3.17.X → 3.17.Y) | `3.17` | *(optional)* | *(optional)* |
| Minor (3.18.X → 3.19.0) | `3` | `3.19` | `3.18.X` |
| Major (3.18.X → 4.0.0)  | `main` | `4.0` | `3.18.X` |

## Latent bug fixed

The previous sample set `base_branch: \${{ github.ref_name }}`. For `repository_dispatch` this is `main` (the default branch), not the target version branch — so patch-bump PRs would have targeted `main` instead of `3.17`. The redesign uses `client_payload.minor` for the base branch on that path.

## Companion change

Consumer repo: [`josh-wong/docs-internal-scalardb` PR #17](https://github.com/josh-wong/docs-internal-scalardb/pull/17) replaces the old caller on `main` and removes the caller file from all 6 version branches (`3`, `3.14`, `3.15`, `3.16`, `3.17`, `3.18`).